### PR TITLE
cluster-autoscaler.spec: bump golang_version to 1.10.4

### DIFF
--- a/cluster-autoscaler.spec
+++ b/cluster-autoscaler.spec
@@ -46,7 +46,7 @@
 # Customize from here.
 #
 
-%global golang_version 1.9.1
+%global golang_version 1.10.4
 %{!?version: %global version 1.2.0}
 %{!?release: %global release 1}
 


### PR DESCRIPTION
Fixes: https://jira.coreos.com/browse/ART-242