### PR TITLE
cluster-autoscaler.spec: set golang_version to 1.10

### DIFF
--- a/cluster-autoscaler.spec
+++ b/cluster-autoscaler.spec
@@ -46,7 +46,7 @@
 # Customize from here.
 #
 
-%global golang_version 1.10.4
+%global golang_version 1.10
 %{!?version: %global version 1.2.0}
 %{!?release: %global release 1}
 


### PR DESCRIPTION
Second pass at fixing this: https://jira.coreos.com/browse/ART-244