### PR TITLE
UPSTREAM: <carry>: gce: increase test timeout in TestWaitForGkeOp

### DIFF
--- a/cluster-autoscaler/cloudprovider/gke/autoscaling_gke_client_v1beta1_test.go
+++ b/cluster-autoscaler/cloudprovider/gke/autoscaling_gke_client_v1beta1_test.go
@@ -66,7 +66,7 @@ func TestWaitForGkeOp(t *testing.T) {
 	g := newTestAutoscalingGkeClientV1beta1(t, "project1", "us-central1-b", "cluster-1", server.URL)
 
 	g.operationPollInterval = 1 * time.Millisecond
-	g.operationWaitTimeout = 50 * time.Millisecond
+	g.operationWaitTimeout = 500 * time.Millisecond
 
 	server.On("handle", "/v1beta1/projects/project1/locations/us-central1-b/operations/operation-1505728466148-d16f5197").Return(operationRunningResponse).Once()
 	server.On("handle", "/v1beta1/projects/project1/locations/us-central1-b/operations/operation-1505728466148-d16f5197").Return(operationDoneResponse).Once()


### PR DESCRIPTION
This is the same change as was done in
https://github.com/kubernetes/autoscaler/pull/1356 where I see
intermittent CI failures on AWS CI instances.

Signed-off-by: Andrew McDermott <amcdermo@redhat.com>