### PR TITLE
UPSTREAM: <carry> Return error if launch configuration name is missing

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -364,7 +364,7 @@ func (m *AwsManager) getAsgTemplate(name string) (*asgTemplate, error) {
 		return nil, err
 	}
 
-	instanceTypeName, err := m.service.getInstanceTypeByLCName(*asg.LaunchConfigurationName)
+	instanceTypeName, err := m.service.getInstanceTypeByLCName(aws.StringValue(asg.LaunchConfigurationName))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When requesting for aws asg it may happen the launch configuration
name is not set (set to nil pointer). Causing the cluster autoscaler
to panic when accesing the nil pointer.

One line change picked from https://github.com/kubernetes/autoscaler/pull/867.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1631635