### PR TITLE
Add release operator label to cluster-autoscaler images

### DIFF
--- a/images/cluster-autoscaler/Dockerfile
+++ b/images/cluster-autoscaler/Dockerfile
@@ -7,3 +7,4 @@ FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/k8s.io/autoscaler/cluster-autoscaler/cluster-autoscaler /usr/bin/
 CMD /usr/bin/cluster-autoscaler
 LABEL summary="Cluster Autoscaler for OpenShift and Kubernetes"
+LABEL io.openshift.release.operator true

--- a/images/cluster-autoscaler/Dockerfile.rhel7
+++ b/images/cluster-autoscaler/Dockerfile.rhel7
@@ -7,3 +7,4 @@ FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /go/src/k8s.io/autoscaler/cluster-autoscaler/cluster-autoscaler /usr/bin/
 CMD /usr/bin/cluster-autoscaler
 LABEL summary="Cluster Autoscaler for OpenShift and Kubernetes"
+LABEL io.openshift.release.operator true


### PR DESCRIPTION
I'm not sure this is the correct approach, but opening this to discuss.

The cluster-autoscaler-operator is deployed by default in OpenShift 4.0, but it does *not* run an autoscaler instance by default, thus the autoscaler image is not included in the release image. If the autoscaler is nevertheless considered part of a release, and the operator should default to running the appropriately tagged image for the release, then I'm guessing the autoscaler itself should also be included in the release image. The CVO can then set the image override in the operator's configuration.

Does that make sense? Or should the operator be using some other method of determining the autoscaler image to use?

cc: @smarterclayton @derekwaynecarr @frobware @enxebre 