### PR TITLE
assign ownership to cloud team

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,11 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
 approvers:
-- mwielgus
-- maciekpytel
-- bskiba
+  - enxebre
+  - frobware
+  - ingvagabund
+  - bison
 reviewers:
-- mwielgus
-- maciekpytel
-- bskiba
+  - paulfantom
+  - spangenberg
+  - vikaschoudhary16


### PR DESCRIPTION
Same as #27. Recreated so we can merge it without failing e2e test.

Assign file ownership to cloud team

CC: @frobware @ingvagabund