### PR TITLE
Temporarily support "openshift-machine-api" as a provider name

### DIFF
--- a/cluster-autoscaler/cloudprovider/builder/cloud_provider_builder.go
+++ b/cluster-autoscaler/cloudprovider/builder/cloud_provider_builder.go
@@ -46,6 +46,7 @@ var AvailableCloudProviders = []string{
 	gke.ProviderNameGKE,
 	kubemark.ProviderName,
 	clusterapi.ProviderName,
+	"openshift-machine-api",
 }
 
 // DefaultCloudProvider is GCE.
@@ -79,6 +80,8 @@ func NewCloudProvider(opts config.AutoscalingOptions) cloudprovider.CloudProvide
 	case kubemark.ProviderName:
 		return buildKubemark(opts, do, rl)
 	case clusterapi.ProviderName:
+		return buildClusterAPI(clusterapi.ProviderName, opts, do, rl)
+	case "openshift-machine-api":
 		return buildClusterAPI(clusterapi.ProviderName, opts, do, rl)
 	case "":
 		// Ideally this would be an error, but several unit tests of the


### PR DESCRIPTION
This allows the machine.openshift.io API pivot to complete.

It will unblock:
- https://github.com/openshift/cluster-autoscaler-operator/pull/35

and once that has landed we can revert this.