### PR TITLE
test/openshift/e2e: Smoke test for scale down

### DIFF
--- a/test/openshift/e2e/operator_expectations.go
+++ b/test/openshift/e2e/operator_expectations.go
@@ -104,7 +104,7 @@ func (tc *testConfig) ExpectAutoscalerScalesOut() error {
 			APIVersion: "autoscaling.openshift.io/v1alpha1",
 		},
 		Spec: caov1alpha1.MachineAutoscalerSpec{
-			MaxReplicas: 12,
+			MaxReplicas: 2,
 			MinReplicas: 1,
 			ScaleTargetRef: caov1alpha1.CrossVersionObjectReference{
 				Name:       targetMachineSet.Name,


### PR DESCRIPTION
Reworked the e2e test to delete the workload. This will:

- delete all workload-based pods
- the autoscaler will notice that there are nodes without any utilisation 
- the autoscaler will scale down

The smoke tests asserts that:
- the MachineSet's replicas drops to its original number.
- the number of nodes in the cluster drops to the original count before scale up

I also reduced the number of replicas we spin up from 12 => 2 as we're only testing for a delta of 1.