### PR TITLE
UPSTREAM: <carry>: test/openshift/e2e: switch namespace to openshift-machine-api

### DIFF
--- a/test/openshift/e2e/main.go
+++ b/test/openshift/e2e/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	namespace = "openshift-cluster-api"
+	namespace = "openshift-machine-api"
 )
 
 func init() {


### PR DESCRIPTION
As we have now pivoted to machine.openshift.io/v1beta1 this changes the namespace when running the tests to `openshift-machine-api` for consistency.