### PR TITLE
UPSTREAM: <carry>: test/openshift/e2e: handle SIGINT and SIGTERM

### DIFF
--- a/test/openshift/Gopkg.lock
+++ b/test/openshift/Gopkg.lock
@@ -412,7 +412,7 @@
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:70c6a336ed3caf7c3747ac5648e908357a0cea5b63121dcdb3c361337699afe4"
+  digest = "1:041d01523e2b563a2e08386a7e9a169f0c4c29c158b7ba63fe4f2b12f89f231c"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
     "pkg/client",
@@ -420,6 +420,7 @@
     "pkg/client/config",
     "pkg/runtime/log",
     "pkg/runtime/scheme",
+    "pkg/runtime/signals",
   ]
   pruneopts = "UT"
   revision = "a67a5036fa19242e7ca874420224bc26753b811f"
@@ -442,6 +443,7 @@
     "k8s.io/client-go/kubernetes/scheme",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",
+    "sigs.k8s.io/controller-runtime/pkg/runtime/signals",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/test/openshift/vendor/sigs.k8s.io/controller-runtime/pkg/runtime/signals/doc.go
+++ b/test/openshift/vendor/sigs.k8s.io/controller-runtime/pkg/runtime/signals/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package signals contains libraries for handling signals to shutdown the system.
+package signals

--- a/test/openshift/vendor/sigs.k8s.io/controller-runtime/pkg/runtime/signals/signal.go
+++ b/test/openshift/vendor/sigs.k8s.io/controller-runtime/pkg/runtime/signals/signal.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signals
+
+import (
+	"os"
+	"os/signal"
+)
+
+var onlyOneSignalHandler = make(chan struct{})
+
+// SetupSignalHandler registered for SIGTERM and SIGINT. A stop channel is returned
+// which is closed on one of these signals. If a second signal is caught, the program
+// is terminated with exit code 1.
+func SetupSignalHandler() (stopCh <-chan struct{}) {
+	close(onlyOneSignalHandler) // panics when called twice
+
+	stop := make(chan struct{})
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, shutdownSignals...)
+	go func() {
+		<-c
+		close(stop)
+		<-c
+		os.Exit(1) // second signal. Exit directly.
+	}()
+
+	return stop
+}

--- a/test/openshift/vendor/sigs.k8s.io/controller-runtime/pkg/runtime/signals/signal_posix.go
+++ b/test/openshift/vendor/sigs.k8s.io/controller-runtime/pkg/runtime/signals/signal_posix.go
@@ -1,0 +1,26 @@
+// +build !windows
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signals
+
+import (
+	"os"
+	"syscall"
+)
+
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}

--- a/test/openshift/vendor/sigs.k8s.io/controller-runtime/pkg/runtime/signals/signal_windows.go
+++ b/test/openshift/vendor/sigs.k8s.io/controller-runtime/pkg/runtime/signals/signal_windows.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signals
+
+import (
+	"os"
+)
+
+var shutdownSignals = []os.Signal{os.Interrupt}


### PR DESCRIPTION
Setup a signal handler in main and also pass a `context.Context` to the `Expect...()` functions. The signal handler will cancel the context and the expect functions can now be notified of the interruption (or cancellation) and run any subsequent cleanup operations.

The `ExpectAutoscalerScalesOut()` test now deletes the following objects on either successful completion of the test or when a `SIGINT` or `SIGTERM` is received:

- workload object (if still present)
- clusterautoscalers
- machineautoscalers

The is particularly handy when running the e2e tests manually as you no longer have to clean up the objects that are created before invoking the test again.
