### PR TITLE
UPSTREAM: <carry>: openshift: rework logic in DeleteNodes()

### DIFF
--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_machinedeployment.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_machinedeployment.go
@@ -75,8 +75,8 @@ func (r machineDeploymentScalableResource) Nodes() ([]string, error) {
 	return result, nil
 }
 
-func (r machineDeploymentScalableResource) Replicas() int32 {
-	return pointer.Int32PtrDerefOr(r.machineDeployment.Spec.Replicas, 0)
+func (r machineDeploymentScalableResource) Replicas() (int, error) {
+	return int(pointer.Int32PtrDerefOr(r.machineDeployment.Spec.Replicas, 0)), nil
 }
 
 func (r machineDeploymentScalableResource) SetSize(nreplicas int32) error {

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_machineset.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_machineset.go
@@ -60,8 +60,8 @@ func (r machineSetScalableResource) Nodes() ([]string, error) {
 	return r.controller.machineSetNodeNames(r.machineSet)
 }
 
-func (r machineSetScalableResource) Replicas() int32 {
-	return pointer.Int32PtrDerefOr(r.machineSet.Spec.Replicas, 0)
+func (r machineSetScalableResource) Replicas() (int, error) {
+	return int(pointer.Int32PtrDerefOr(r.machineSet.Spec.Replicas, 0)), nil
 }
 
 func (r machineSetScalableResource) SetSize(nreplicas int32) error {

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_scalableresource.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_scalableresource.go
@@ -42,5 +42,5 @@ type scalableResource interface {
 	SetSize(nreplicas int32) error
 
 	// Replicas returns the current replica count of the resource
-	Replicas() int32
+	Replicas() (int, error)
 }


### PR DESCRIPTION
This reworks the logic in `DeleteNodes([]nodes)` to:

- annotate a node for deletion
- drop the replica count by 1 immediately
- fail fast on any error during those steps

This is different from the current behaviour which first annotated all the nodes then dropped the replica count by `len(nodes)`. The goal here is to not leave machines and the respective machine set replica count in an indeterminate state should any error occur.

The downside is that if you try and delete 1000 nodes then there will be 1000 calls to drop the replica count, as opposed to the current behaviour of just 1.

This builds on top of PR #36 which in turn builds on top of #34.