### PR TITLE
UPSTREAM: <carry>: openshift: log nodegroup discovery at level 4

### DIFF
--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_provider.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_provider.go
@@ -62,7 +62,7 @@ func (p *provider) NodeGroups() []cloudprovider.NodeGroup {
 		return nil
 	}
 	for _, ng := range nodegroups {
-		glog.Infof("discovered node group: %s", ng.Debug())
+		glog.V(4).Infof("discovered node group: %s", ng.Debug())
 	}
 	return nodegroups
 }


### PR DESCRIPTION
This value is printed a lot during normal execution and it is really
for debug only so logging at level 4.