### PR TITLE
UPSTREAM: <carry>: test/openshift/e2e: add Autoscaler focused target

### DIFF
--- a/test/openshift/Makefile
+++ b/test/openshift/Makefile
@@ -2,12 +2,19 @@
 deps:
 	dep ensure -v
 
-.PHONY: test-e2e
-test-e2e: ## Run openshift specific e2e test
+define test =
 	go test -timeout 60m \
 		-v ./vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e \
 		-kubeconfig $${KUBECONFIG:-~/.kube/config} \
 		-machine-api-namespace $${NAMESPACE:-openshift-machine-api} \
-		-ginkgo.v \
-		-args -v 5 -logtostderr
+		-args -v 5 -logtostderr \
+		$1 $2 $3 $4 $5 $6 $7 $8 $9
+endef
 
+.PHONY: test-e2e
+test-e2e: ## Run openshift specific e2e test
+	time $(call test,-ginkgo.v,-ginkgo.noColor=true)
+
+.PHONY: test-e2e-autoscaler
+test-e2e-autoscaler: ## Run autoscaler focused tests only
+	time $(call test,-ginkgo.v,-ginkgo.focus=Autoscaler,-ginkgo.noColor=true)


### PR DESCRIPTION
This target is to help those developing the autoscaler cloud provider.
It focuses on autoscaler tests only.

- For all ginkgo e2e tests it also sets `-ginkgo.noColor=true` which
  can help when parsing logs from the CLI.