### PR TITLE
UPSTREAM: <carry>: openshift: cluster-autoscaler/core: print correct error

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -338,7 +338,7 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 			metrics.UpdateDurationFromStart(metrics.ScaleDown, scaleDownStart)
 
 			if typedErr != nil {
-				glog.Errorf("Failed to scale down: %v", err)
+				glog.Errorf("Failed to scale down: %v", typedErr)
 				a.lastScaleDownFailTime = currentTime
 				return typedErr
 			}


### PR DESCRIPTION
Print the correct error variable if a scale down error occurs.
Previously this was printing `err` which was a) not the correct
variable and b) would always have the value `<nil>`.