### PR TITLE
UPSTREAM: <carry>: test/openshift: go get dep if it doesn't exist

### DIFF
--- a/test/openshift/Makefile
+++ b/test/openshift/Makefile
@@ -1,5 +1,6 @@
 .PHONY: deps
 deps:
+	type -P dep 2>&1 > /dev/null || go get -u github.com/golang/dep/cmd/dep
 	dep ensure -v
 
 define test =


### PR DESCRIPTION
Ensure dep(1) is available before running it.