### PR TITLE
UPSTREAM: <carry>: test/openshift/Makefile: add rule to bump deps

### DIFF
--- a/test/openshift/Makefile
+++ b/test/openshift/Makefile
@@ -1,6 +1,9 @@
-.PHONY: deps
-deps:
+.PHONY: dep deps
+
+dep:
 	type -P dep 2>&1 > /dev/null || go get -u github.com/golang/dep/cmd/dep
+
+deps: dep
 	dep ensure -v
 
 define test =
@@ -19,3 +22,10 @@ test-e2e: ## Run openshift specific e2e test
 .PHONY: test-e2e-autoscaler
 test-e2e-autoscaler: ## Run autoscaler focused tests only
 	time $(call test,-ginkgo.v,-ginkgo.focus=Autoscaler,-ginkgo.noColor=true)
+
+.PHONY: revendor-test-e2e
+revendor-test-e2e: dep
+	curl --silent -o e2e_test.go https://raw.githubusercontent.com/openshift/cluster-api-actuator-pkg/master/pkg/e2e/e2e_test.go
+	dep ensure -update github.com/openshift/cluster-api-actuator-pkg
+	dep ensure -v
+	$(RM) e2e_test.go


### PR DESCRIPTION
 Add a makefile target `revendor-test-e2e` that captures the runes to bump the e2e test dependencies.