### PR TITLE
UPSTREAM: <carry>: openshift: Rework TestNodeGroupNewNodeGroup

### DIFF
--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller_test.go
@@ -831,7 +831,7 @@ func TestControllerNodeGroupForNodeLookup(t *testing.T) {
 
 			machineSet, machineDeployment := makeMachineOwner(i, 1, annotations, useMachineDeployment)
 
-			node, machine := makeLinkedNodeAndMachine(i, v1.OwnerReference{
+			node, machine := makeLinkedNodeAndMachine(i, machineSet.Namespace, v1.OwnerReference{
 				Name: machineSet.Name,
 				Kind: machineSet.Kind,
 				UID:  machineSet.UID,


### PR DESCRIPTION
This is the beginning of a sequence of commits to change the test functions in nodegroup to use subtests. The intent is to ensure we are testing both MachineSets and MachineDeployments in all cases we construct a nodegroup.

By switching to subtests it will become easier to see those places where machine deployments are not being tested as the the output for each test function should show that `MachineDeployment` and `MachineSet` is listed in the test name output.

```console
--- PASS: TestNodeGroupNewNodeGroup (0.00s)
    --- PASS: TestNodeGroupNewNodeGroup/MachineDeployment (0.00s)
        --- PASS: TestNodeGroupNewNodeGroup/MachineDeployment/errors_because_minSize_is_invalid (0.10s)
        --- PASS: TestNodeGroupNewNodeGroup/MachineDeployment/errors_because_maxSize_is_invalid (0.11s)
        --- PASS: TestNodeGroupNewNodeGroup/MachineDeployment/errors_because_maxSize_<_minSize (0.11s)
        --- PASS: TestNodeGroupNewNodeGroup/MachineDeployment/errors_because_minSize_>_maxSize (0.11s)
        --- PASS: TestNodeGroupNewNodeGroup/MachineDeployment/no_error:_min=0,_max=1 (0.12s)
        --- PASS: TestNodeGroupNewNodeGroup/MachineDeployment/no_error:_min=0,_max=0 (0.13s)
        --- PASS: TestNodeGroupNewNodeGroup/MachineDeployment/no_error:_min=1,_max=10,_replicas=5 (0.13s)
    --- PASS: TestNodeGroupNewNodeGroup/MachineSet (0.00s)
        --- PASS: TestNodeGroupNewNodeGroup/MachineSet/errors_because_minSize_>_maxSize (0.10s)
        --- PASS: TestNodeGroupNewNodeGroup/MachineSet/no_error:_min=0,_max=1 (0.10s)
        --- PASS: TestNodeGroupNewNodeGroup/MachineSet/errors_because_minSize_is_invalid (0.10s)
        --- PASS: TestNodeGroupNewNodeGroup/MachineSet/errors_because_maxSize_<_minSize (0.12s)
        --- PASS: TestNodeGroupNewNodeGroup/MachineSet/no_error:_min=0,_max=0 (0.13s)
        --- PASS: TestNodeGroupNewNodeGroup/MachineSet/no_error:_min=1,_max=10,_replicas=5 (0.13s)
        --- PASS: TestNodeGroupNewNodeGroup/MachineSet/errors_because_maxSize_is_invalid (0.13s)
```

No code outside of the unit tests has been changed.