### PR TITLE
UPSTREAM: <carry>: openshift: Rework TestControllerNodeGroupForNodeLookup

### DIFF
--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller_test.go
@@ -803,11 +803,13 @@ func TestControllerNodeGroupsWithMachineSets(t *testing.T) {
 }
 
 func TestControllerNodeGroupForNodeLookup(t *testing.T) {
-	for i, tc := range []struct {
+	type testCase struct {
 		description    string
 		annotations    map[string]string
 		lookupSucceeds bool
-	}{{
+	}
+
+	var testCases = []testCase{{
 		description:    "lookup is nil because no annotations",
 		annotations:    map[string]string{},
 		lookupSucceeds: false,
@@ -825,64 +827,59 @@ func TestControllerNodeGroupForNodeLookup(t *testing.T) {
 			nodeGroupMaxSizeAnnotationKey: "2",
 		},
 		lookupSucceeds: true,
-	}} {
-		test := func(t *testing.T, i int, annotations map[string]string, useMachineDeployment bool) {
-			t.Helper()
+	}}
 
-			machineSet, machineDeployment := makeMachineOwner(i, 1, annotations, useMachineDeployment)
+	test := func(t *testing.T, tc testCase, testObjs *clusterTestConfig, node *apiv1.Node) {
+		t.Helper()
 
-			node, machine := makeLinkedNodeAndMachine(i, machineSet.Namespace, v1.OwnerReference{
-				Name: machineSet.Name,
-				Kind: machineSet.Kind,
-				UID:  machineSet.UID,
-			})
+		controller, stop := testObjs.newMachineController(t)
+		defer stop()
 
-			machineObjects := []runtime.Object{
-				machine,
-				machineSet,
-			}
-
-			if machineDeployment != nil {
-				machineObjects = append(machineObjects, machineDeployment)
-			}
-
-			controller, stop := mustCreateTestController(t, testControllerConfig{
-				nodeObjects:    []runtime.Object{node},
-				machineObjects: machineObjects,
-			})
-			defer stop()
-
-			ng, err := controller.nodeGroupForNode(node)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if ng == nil && tc.lookupSucceeds {
-				t.Fatalf("expected nil from lookup")
-			}
-
-			if ng != nil && !tc.lookupSucceeds {
-				t.Fatalf("expected non-nil from lookup")
-			}
-
-			if tc.lookupSucceeds {
-				var expected string
-
-				if useMachineDeployment {
-					expected = path.Join(machineDeployment.Namespace, machineDeployment.Name)
-				} else {
-					expected = path.Join(machineSet.Namespace, machineSet.Name)
-				}
-
-				if actual := ng.Id(); actual != expected {
-					t.Errorf("expected %q, got %q", expected, actual)
-				}
-			}
+		ng, err := controller.nodeGroupForNode(node)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 
-		t.Run(tc.description, func(t *testing.T) {
-			test(t, i, tc.annotations, true) // with MachineDeployment
-			test(t, i, tc.annotations, false)
-		})
+		if ng == nil && tc.lookupSucceeds {
+			t.Fatalf("expected non-nil from lookup")
+		}
+
+		if ng != nil && !tc.lookupSucceeds {
+			t.Fatalf("expected nil from lookup")
+		}
+
+		if !tc.lookupSucceeds {
+			return
+		}
+
+		var expected string
+
+		if testObjs.machineDeployment != nil {
+			expected = path.Join(testObjs.machineDeployment.Namespace, testObjs.machineDeployment.Name)
+		} else {
+			expected = path.Join(testObjs.machineSet.Namespace, testObjs.machineSet.Name)
+		}
+
+		if actual := ng.Id(); actual != expected {
+			t.Errorf("expected %q, got %q", expected, actual)
+		}
 	}
+
+	t.Run("MachineSet", func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.description, func(t *testing.T) {
+				testObjs, _ := newMachineSetTestObjs(t.Name(), 0, 1, 1, tc.annotations)
+				test(t, tc, testObjs, testObjs.nodes[0].DeepCopy())
+			})
+		}
+	})
+
+	t.Run("MachineDeployment", func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.description, func(t *testing.T) {
+				testObjs, _ := newMachineDeploymentTestObjs(t.Name(), 0, 1, 1, tc.annotations)
+				test(t, tc, testObjs, testObjs.nodes[0].DeepCopy())
+			})
+		}
+	})
 }


### PR DESCRIPTION
This reworks TestControllerNodeGroupForNodeLookup to use subtests. The
change is to ensure we are testing both MachineSets and
MachineDeployments in all cases we construct a nodegroup.

By switching to subtests it is easier to see those places where
machine deployments are not being tested as the the output for each
test function should show that MachineDeployment and MachineSet is
listed in the test name output.

```console
--- PASS: TestControllerNodeGroupForNodeLookup (0.61s)
    --- PASS: TestControllerNodeGroupForNodeLookup/MachineSet (0.30s)
        --- PASS: TestControllerNodeGroupForNodeLookup/MachineSet/lookup_is_nil_because_no_annotations (0.10s)
        --- PASS: TestControllerNodeGroupForNodeLookup/MachineSet/lookup_is_nil_because_scaling_range_==_0 (0.10s)
        --- PASS: TestControllerNodeGroupForNodeLookup/MachineSet/lookup_is_successful_because_scaling_range_>=_1 (0.10s)
    --- PASS: TestControllerNodeGroupForNodeLookup/MachineDeployment (0.30s)
        --- PASS: TestControllerNodeGroupForNodeLookup/MachineDeployment/lookup_is_nil_because_no_annotations (0.10s)
        --- PASS: TestControllerNodeGroupForNodeLookup/MachineDeployment/lookup_is_nil_because_scaling_range_==_0 (0.10s)
        --- PASS: TestControllerNodeGroupForNodeLookup/MachineDeployment/lookup_is_successful_because_scaling_range_>=_1 (0.10s)
```