### PR TITLE
UPSTREAM: <carry>: openshift: check for explicit errors

### DIFF
--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup.go
@@ -116,7 +116,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*apiv1.Node) error {
 	}
 
 	if int(ng.scalableResource.Replicas())-len(nodes) <= 0 {
-		return fmt.Errorf("unable to delete %d machines in %q, machine replicas are <= 0 ", len(nodes), ng.Id())
+		return fmt.Errorf("unable to delete %d machines in %q, machine replicas are <= 0", len(nodes), ng.Id())
 	}
 
 	return ng.scalableResource.SetSize(ng.scalableResource.Replicas() - int32(len(nodes)))


### PR DESCRIPTION
Check for explicit error mesages in TestNodeGroupIncreaseSize() and
TestNodeGroupDecreaseSize(). These functions now only test the
expected error cases on bad inputs. A follow-up PR will test for the
success case which needs additional test setup code.
