### PR TITLE
UPSTREAM: <carry>: openshift: clean up test setup

### DIFF
--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller.go
@@ -166,7 +166,7 @@ func (c *machineController) findMachineByNodeProviderID(node *apiv1.Node) (*v1be
 		return nil, fmt.Errorf("internal error; unexpected type %T", node)
 	}
 
-	if machineName, found := node.Annotations["machine.openshift.io/machine"]; found {
+	if machineName, found := node.Annotations[machineAnnotationKey]; found {
 		return c.findMachine(machineName)
 	}
 

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller_test.go
@@ -92,23 +92,23 @@ func mustCreateTestController(t *testing.T, testConfigs ...*testConfig) (*machin
 	}
 }
 
-func mustCreateMachineSetTestConfig(namespace string, nodeCount int, replicaCount int32, annotations map[string]string) *testConfig {
-	return mustCreateTestConfigs(mustCreateTestSpecs(namespace, 1, nodeCount, replicaCount, false, annotations)...)[0]
+func createMachineSetTestConfig(namespace string, nodeCount int, replicaCount int32, annotations map[string]string) *testConfig {
+	return createTestConfigs(createTestSpecs(namespace, 1, nodeCount, replicaCount, false, annotations)...)[0]
 }
 
-func mustCreateMachineSetTestConfigs(namespace string, configCount, nodeCount int, replicaCount int32, annotations map[string]string) []*testConfig {
-	return mustCreateTestConfigs(mustCreateTestSpecs(namespace, configCount, nodeCount, replicaCount, false, annotations)...)
+func createMachineSetTestConfigs(namespace string, configCount, nodeCount int, replicaCount int32, annotations map[string]string) []*testConfig {
+	return createTestConfigs(createTestSpecs(namespace, configCount, nodeCount, replicaCount, false, annotations)...)
 }
 
-func mustCreateMachineDeploymentTestConfig(namespace string, nodeCount int, replicaCount int32, annotations map[string]string) *testConfig {
-	return mustCreateTestConfigs(mustCreateTestSpecs(namespace, 1, nodeCount, replicaCount, true, annotations)...)[0]
+func createMachineDeploymentTestConfig(namespace string, nodeCount int, replicaCount int32, annotations map[string]string) *testConfig {
+	return createTestConfigs(createTestSpecs(namespace, 1, nodeCount, replicaCount, true, annotations)...)[0]
 }
 
-func mustCreateMachineDeploymentTestConfigs(namespace string, configCount, nodeCount int, replicaCount int32, annotations map[string]string) []*testConfig {
-	return mustCreateTestConfigs(mustCreateTestSpecs(namespace, configCount, nodeCount, replicaCount, true, annotations)...)
+func createMachineDeploymentTestConfigs(namespace string, configCount, nodeCount int, replicaCount int32, annotations map[string]string) []*testConfig {
+	return createTestConfigs(createTestSpecs(namespace, configCount, nodeCount, replicaCount, true, annotations)...)
 }
 
-func mustCreateTestSpecs(namespace string, scalableResourceCount, nodeCount int, replicaCount int32, isMachineDeployment bool, annotations map[string]string) []testSpec {
+func createTestSpecs(namespace string, scalableResourceCount, nodeCount int, replicaCount int32, isMachineDeployment bool, annotations map[string]string) []testSpec {
 	var specs []testSpec
 
 	for i := 0; i < scalableResourceCount; i++ {
@@ -126,7 +126,7 @@ func mustCreateTestSpecs(namespace string, scalableResourceCount, nodeCount int,
 	return specs
 }
 
-func mustCreateTestConfigs(specs ...testSpec) []*testConfig {
+func createTestConfigs(specs ...testSpec) []*testConfig {
 	var result []*testConfig
 
 	for i, spec := range specs {
@@ -336,7 +336,7 @@ func TestControllerFindMachineByID(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			testConfig := mustCreateMachineSetTestConfig(testNamespace, 1, 1, map[string]string{
+			testConfig := createMachineSetTestConfig(testNamespace, 1, 1, map[string]string{
 				nodeGroupMinSizeAnnotationKey: "1",
 				nodeGroupMaxSizeAnnotationKey: "10",
 			})
@@ -352,7 +352,7 @@ func TestControllerFindMachineByID(t *testing.T) {
 }
 
 func TestControllerFindMachineOwner(t *testing.T) {
-	testConfig := mustCreateMachineSetTestConfig(testNamespace, 1, 1, map[string]string{
+	testConfig := createMachineSetTestConfig(testNamespace, 1, 1, map[string]string{
 		nodeGroupMinSizeAnnotationKey: "1",
 		nodeGroupMaxSizeAnnotationKey: "10",
 	})
@@ -397,7 +397,7 @@ func TestControllerFindMachineOwner(t *testing.T) {
 }
 
 func TestControllerFindMachineByNodeProviderID(t *testing.T) {
-	testConfig := mustCreateMachineSetTestConfig(testNamespace, 1, 1, map[string]string{
+	testConfig := createMachineSetTestConfig(testNamespace, 1, 1, map[string]string{
 		nodeGroupMinSizeAnnotationKey: "1",
 		nodeGroupMaxSizeAnnotationKey: "10",
 	})
@@ -446,7 +446,7 @@ func TestControllerFindMachineByNodeProviderID(t *testing.T) {
 }
 
 func TestControllerFindNodeByNodeName(t *testing.T) {
-	testConfig := mustCreateMachineSetTestConfig(testNamespace, 1, 1, map[string]string{
+	testConfig := createMachineSetTestConfig(testNamespace, 1, 1, map[string]string{
 		nodeGroupMinSizeAnnotationKey: "1",
 		nodeGroupMaxSizeAnnotationKey: "10",
 	})
@@ -474,7 +474,7 @@ func TestControllerFindNodeByNodeName(t *testing.T) {
 }
 
 func TestControllerMachinesInMachineSet(t *testing.T) {
-	testConfig1 := mustCreateMachineSetTestConfig("testConfig1", 5, 5, map[string]string{
+	testConfig1 := createMachineSetTestConfig("testConfig1", 5, 5, map[string]string{
 		nodeGroupMinSizeAnnotationKey: "1",
 		nodeGroupMaxSizeAnnotationKey: "10",
 	})
@@ -486,7 +486,7 @@ func TestControllerMachinesInMachineSet(t *testing.T) {
 	// nodes and the additional machineset to the existing set of
 	// test objects in the controller. This gives us two
 	// machinesets, each with their own machines and linked nodes.
-	testConfig2 := mustCreateMachineSetTestConfig("testConfig2", 5, 5, map[string]string{
+	testConfig2 := createMachineSetTestConfig("testConfig2", 5, 5, map[string]string{
 		nodeGroupMinSizeAnnotationKey: "1",
 		nodeGroupMaxSizeAnnotationKey: "10",
 	})
@@ -547,7 +547,7 @@ func TestControllerMachinesInMachineSet(t *testing.T) {
 }
 
 func TestControllerLookupNodeGroupForNonExistentNode(t *testing.T) {
-	testConfig := mustCreateMachineSetTestConfig(testNamespace, 1, 1, map[string]string{
+	testConfig := createMachineSetTestConfig(testNamespace, 1, 1, map[string]string{
 		nodeGroupMinSizeAnnotationKey: "1",
 		nodeGroupMaxSizeAnnotationKey: "10",
 	})
@@ -593,7 +593,7 @@ func TestControllerNodeGroupForNodeWithMissingMachineOwner(t *testing.T) {
 	}
 
 	t.Run("MachineSet", func(t *testing.T) {
-		testConfig := mustCreateMachineSetTestConfig(testNamespace, 1, 1, map[string]string{
+		testConfig := createMachineSetTestConfig(testNamespace, 1, 1, map[string]string{
 			nodeGroupMinSizeAnnotationKey: "1",
 			nodeGroupMaxSizeAnnotationKey: "10",
 		})
@@ -601,7 +601,7 @@ func TestControllerNodeGroupForNodeWithMissingMachineOwner(t *testing.T) {
 	})
 
 	t.Run("MachineDeployment", func(t *testing.T) {
-		testConfig := mustCreateMachineDeploymentTestConfig(testNamespace, 1, 1, map[string]string{
+		testConfig := createMachineDeploymentTestConfig(testNamespace, 1, 1, map[string]string{
 			nodeGroupMinSizeAnnotationKey: "1",
 			nodeGroupMaxSizeAnnotationKey: "10",
 		})
@@ -626,7 +626,7 @@ func TestControllerNodeGroupForNodeWithPositiveScalingBounds(t *testing.T) {
 	}
 
 	t.Run("MachineSet", func(t *testing.T) {
-		testConfig := mustCreateMachineSetTestConfig(testNamespace, 1, 1, map[string]string{
+		testConfig := createMachineSetTestConfig(testNamespace, 1, 1, map[string]string{
 			nodeGroupMinSizeAnnotationKey: "1",
 			nodeGroupMaxSizeAnnotationKey: "1",
 		})
@@ -634,7 +634,7 @@ func TestControllerNodeGroupForNodeWithPositiveScalingBounds(t *testing.T) {
 	})
 
 	t.Run("MachineDeployment", func(t *testing.T) {
-		testConfig := mustCreateMachineDeploymentTestConfig(testNamespace, 1, 1, map[string]string{
+		testConfig := createMachineDeploymentTestConfig(testNamespace, 1, 1, map[string]string{
 			nodeGroupMinSizeAnnotationKey: "1",
 			nodeGroupMaxSizeAnnotationKey: "1",
 		})
@@ -666,14 +666,14 @@ func TestControllerNodeGroups(t *testing.T) {
 	assertNodegroupLen(t, controller, 0)
 
 	// Test #2: add 5 machineset-based nodegroups
-	machineSetConfigs := mustCreateMachineSetTestConfigs("MachineSet", 5, 1, 1, annotations)
+	machineSetConfigs := createMachineSetTestConfigs("MachineSet", 5, 1, 1, annotations)
 	if err := addTestConfigs(t, controller, machineSetConfigs...); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	assertNodegroupLen(t, controller, 5)
 
 	// Test #2: add 2 machinedeployment-based nodegroups
-	machineDeploymentConfigs := mustCreateMachineDeploymentTestConfigs("MachineDeployment", 2, 1, 1, annotations)
+	machineDeploymentConfigs := createMachineDeploymentTestConfigs("MachineDeployment", 2, 1, 1, annotations)
 	if err := addTestConfigs(t, controller, machineDeploymentConfigs...); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -697,14 +697,14 @@ func TestControllerNodeGroups(t *testing.T) {
 	}
 
 	// Test #5: machineset with no scaling bounds results in no nodegroups
-	machineSetConfigs = mustCreateMachineSetTestConfigs("MachineSet", 5, 1, 1, annotations)
+	machineSetConfigs = createMachineSetTestConfigs("MachineSet", 5, 1, 1, annotations)
 	if err := addTestConfigs(t, controller, machineSetConfigs...); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	assertNodegroupLen(t, controller, 0)
 
 	// Test #6: machinedeployment with no scaling bounds results in no nodegroups
-	machineDeploymentConfigs = mustCreateMachineDeploymentTestConfigs("MachineDeployment", 2, 1, 1, annotations)
+	machineDeploymentConfigs = createMachineDeploymentTestConfigs("MachineDeployment", 2, 1, 1, annotations)
 	if err := addTestConfigs(t, controller, machineDeploymentConfigs...); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -716,7 +716,7 @@ func TestControllerNodeGroups(t *testing.T) {
 	}
 
 	// Test #7: machineset with bad scaling bounds results in an error and no nodegroups
-	machineSetConfigs = mustCreateMachineSetTestConfigs("MachineSet", 5, 1, 1, annotations)
+	machineSetConfigs = createMachineSetTestConfigs("MachineSet", 5, 1, 1, annotations)
 	if err := addTestConfigs(t, controller, machineSetConfigs...); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -725,7 +725,7 @@ func TestControllerNodeGroups(t *testing.T) {
 	}
 
 	// Test #8: machinedeployment with bad scaling bounds results in an error and no nodegroups
-	machineDeploymentConfigs = mustCreateMachineDeploymentTestConfigs("MachineDeployment", 2, 1, 1, annotations)
+	machineDeploymentConfigs = createMachineDeploymentTestConfigs("MachineDeployment", 2, 1, 1, annotations)
 	if err := addTestConfigs(t, controller, machineDeploymentConfigs...); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -781,13 +781,13 @@ func TestControllerNodeGroupsNodeCount(t *testing.T) {
 
 	t.Run("MachineSet", func(t *testing.T) {
 		for _, tc := range testCases {
-			test(t, tc, mustCreateMachineSetTestConfigs(testNamespace, tc.nodeGroups, tc.nodesPerGroup, int32(tc.nodesPerGroup), annotations))
+			test(t, tc, createMachineSetTestConfigs(testNamespace, tc.nodeGroups, tc.nodesPerGroup, int32(tc.nodesPerGroup), annotations))
 		}
 	})
 
 	t.Run("MachineDeployment", func(t *testing.T) {
 		for _, tc := range testCases {
-			test(t, tc, mustCreateMachineDeploymentTestConfigs(testNamespace, tc.nodeGroups, tc.nodesPerGroup, int32(tc.nodesPerGroup), annotations))
+			test(t, tc, createMachineDeploymentTestConfigs(testNamespace, tc.nodeGroups, tc.nodesPerGroup, int32(tc.nodesPerGroup), annotations))
 		}
 	})
 }

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	machineDeleteAnnotationKey = "machine.openshift.io/cluster-api-delete-machine"
+	machineAnnotationKey       = "machine.openshift.io/machine"
 )
 
 type nodegroup struct {

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup.go
@@ -30,6 +30,7 @@ import (
 const (
 	machineDeleteAnnotationKey = "machine.openshift.io/cluster-api-delete-machine"
 	machineAnnotationKey       = "machine.openshift.io/machine"
+	debugFormat                = "%s (min: %d, max: %d, replicas: %d)"
 )
 
 type nodegroup struct {
@@ -159,7 +160,7 @@ func (ng *nodegroup) Id() string {
 
 // Debug returns a string containing all information regarding this node group.
 func (ng *nodegroup) Debug() string {
-	return fmt.Sprintf("%s (min: %d, max: %d, replicas: %d)", ng.Id(), ng.MinSize(), ng.MaxSize(), ng.scalableResource.Replicas())
+	return fmt.Sprintf(debugFormat, ng.Id(), ng.MinSize(), ng.MaxSize(), ng.scalableResource.Replicas())
 }
 
 // Nodes returns a list of all nodes that belong to this node group.

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup_test.go
@@ -141,7 +141,7 @@ func TestNodeGroupNewNodeGroupConstructor(t *testing.T) {
 		}
 
 		expectedID := path.Join(testConfig.spec.namespace, expectedName)
-		expectedDebug := fmt.Sprintf("%s (min: %d, max: %d, replicas: %d)", expectedID, tc.minSize, tc.maxSize, tc.replicas)
+		expectedDebug := fmt.Sprintf(debugFormat, expectedID, tc.minSize, tc.maxSize, tc.replicas)
 
 		if ng.Name() != expectedName {
 			t.Errorf("expected %q, got %q", expectedName, ng.Name())

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup_test.go
@@ -193,7 +193,7 @@ func TestNodeGroupNewNodeGroupConstructor(t *testing.T) {
 	t.Run("MachineSet", func(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.description, func(t *testing.T) {
-				test(t, tc, mustCreateMachineSetTestConfig(testNamespace, tc.nodeCount, tc.replicas, tc.annotations))
+				test(t, tc, createMachineSetTestConfig(testNamespace, tc.nodeCount, tc.replicas, tc.annotations))
 			})
 		}
 	})
@@ -201,7 +201,7 @@ func TestNodeGroupNewNodeGroupConstructor(t *testing.T) {
 	t.Run("MachineDeployment", func(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.description, func(t *testing.T) {
-				test(t, tc, mustCreateMachineDeploymentTestConfig(testNamespace, tc.nodeCount, tc.replicas, tc.annotations))
+				test(t, tc, createMachineDeploymentTestConfig(testNamespace, tc.nodeCount, tc.replicas, tc.annotations))
 			})
 		}
 	})
@@ -296,7 +296,7 @@ func TestNodeGroupIncreaseSizeErrors(t *testing.T) {
 					nodeGroupMinSizeAnnotationKey: "1",
 					nodeGroupMaxSizeAnnotationKey: "10",
 				}
-				test(t, &tc, mustCreateMachineSetTestConfig(testNamespace, int(tc.initial), tc.initial, annotations))
+				test(t, &tc, createMachineSetTestConfig(testNamespace, int(tc.initial), tc.initial, annotations))
 			})
 		}
 	})
@@ -308,7 +308,7 @@ func TestNodeGroupIncreaseSizeErrors(t *testing.T) {
 					nodeGroupMinSizeAnnotationKey: "1",
 					nodeGroupMaxSizeAnnotationKey: "10",
 				}
-				test(t, &tc, mustCreateMachineDeploymentTestConfig(testNamespace, int(tc.initial), tc.initial, annotations))
+				test(t, &tc, createMachineDeploymentTestConfig(testNamespace, int(tc.initial), tc.initial, annotations))
 			})
 		}
 	})
@@ -385,7 +385,7 @@ func TestNodeGroupIncreaseSize(t *testing.T) {
 			expected:    4,
 			delta:       1,
 		}
-		test(t, &tc, mustCreateMachineSetTestConfig(testNamespace, int(tc.initial), tc.initial, annotations))
+		test(t, &tc, createMachineSetTestConfig(testNamespace, int(tc.initial), tc.initial, annotations))
 	})
 
 	t.Run("MachineDeployment", func(t *testing.T) {
@@ -395,7 +395,7 @@ func TestNodeGroupIncreaseSize(t *testing.T) {
 			expected:    4,
 			delta:       1,
 		}
-		test(t, &tc, mustCreateMachineDeploymentTestConfig(testNamespace, int(tc.initial), tc.initial, annotations))
+		test(t, &tc, createMachineDeploymentTestConfig(testNamespace, int(tc.initial), tc.initial, annotations))
 	})
 }
 
@@ -477,7 +477,7 @@ func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 			expected:    2,
 			delta:       -1,
 		}
-		test(t, &tc, mustCreateMachineSetTestConfig(testNamespace, int(tc.initial), tc.initial, annotations))
+		test(t, &tc, createMachineSetTestConfig(testNamespace, int(tc.initial), tc.initial, annotations))
 	})
 
 	t.Run("MachineDeployment", func(t *testing.T) {
@@ -487,7 +487,7 @@ func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 			expected:    2,
 			delta:       -1,
 		}
-		test(t, &tc, mustCreateMachineDeploymentTestConfig(testNamespace, int(tc.initial), tc.initial, annotations))
+		test(t, &tc, createMachineDeploymentTestConfig(testNamespace, int(tc.initial), tc.initial, annotations))
 	})
 }
 
@@ -580,7 +580,7 @@ func TestNodeGroupDecreaseSizeErrors(t *testing.T) {
 					nodeGroupMinSizeAnnotationKey: "1",
 					nodeGroupMaxSizeAnnotationKey: "10",
 				}
-				test(t, &tc, mustCreateMachineSetTestConfig(testNamespace, int(tc.initial), tc.initial, annotations))
+				test(t, &tc, createMachineSetTestConfig(testNamespace, int(tc.initial), tc.initial, annotations))
 			})
 		}
 	})
@@ -592,7 +592,7 @@ func TestNodeGroupDecreaseSizeErrors(t *testing.T) {
 					nodeGroupMinSizeAnnotationKey: "1",
 					nodeGroupMaxSizeAnnotationKey: "10",
 				}
-				test(t, &tc, mustCreateMachineDeploymentTestConfig(testNamespace, int(tc.initial), tc.initial, annotations))
+				test(t, &tc, createMachineDeploymentTestConfig(testNamespace, int(tc.initial), tc.initial, annotations))
 			})
 		}
 	})
@@ -674,14 +674,14 @@ func TestNodeGroupDeleteNodes(t *testing.T) {
 	// sorting and the expected semantics in test() will fail.
 
 	t.Run("MachineSet", func(t *testing.T) {
-		test(t, mustCreateMachineSetTestConfig(testNamespace, 10, 10, map[string]string{
+		test(t, createMachineSetTestConfig(testNamespace, 10, 10, map[string]string{
 			nodeGroupMinSizeAnnotationKey: "1",
 			nodeGroupMaxSizeAnnotationKey: "10",
 		}))
 	})
 
 	t.Run("MachineDeployment", func(t *testing.T) {
-		test(t, mustCreateMachineDeploymentTestConfig(testNamespace, 10, 10, map[string]string{
+		test(t, createMachineDeploymentTestConfig(testNamespace, 10, 10, map[string]string{
 			nodeGroupMinSizeAnnotationKey: "1",
 			nodeGroupMaxSizeAnnotationKey: "10",
 		}))
@@ -762,14 +762,14 @@ func TestNodeGroupMachineSetDeleteNodesWithMismatchedNodes(t *testing.T) {
 	}
 
 	t.Run("MachineSet", func(t *testing.T) {
-		testConfig0 := mustCreateMachineSetTestConfigs(testNamespace+"0", 1, 2, 2, annotations)
-		testConfig1 := mustCreateMachineSetTestConfigs(testNamespace+"1", 1, 2, 2, annotations)
+		testConfig0 := createMachineSetTestConfigs(testNamespace+"0", 1, 2, 2, annotations)
+		testConfig1 := createMachineSetTestConfigs(testNamespace+"1", 1, 2, 2, annotations)
 		test(t, 2, append(testConfig0, testConfig1...))
 	})
 
 	t.Run("MachineDeployment", func(t *testing.T) {
-		testConfig0 := mustCreateMachineDeploymentTestConfigs(testNamespace+"0", 1, 2, 2, annotations)
-		testConfig1 := mustCreateMachineDeploymentTestConfigs(testNamespace+"1", 1, 2, 2, annotations)
+		testConfig0 := createMachineDeploymentTestConfigs(testNamespace+"0", 1, 2, 2, annotations)
+		testConfig1 := createMachineDeploymentTestConfigs(testNamespace+"1", 1, 2, 2, annotations)
 		test(t, 2, append(testConfig0, testConfig1...))
 	})
 }

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup_test.go
@@ -29,8 +29,7 @@ import (
 )
 
 const (
-	machineAnnotationKey = "machine.openshift.io/machine"
-	testNamespace        = "test-namespace"
+	testNamespace = "test-namespace"
 )
 
 func TestNodeGroupNewNodeGroupConstructor(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_provider_test.go
@@ -28,7 +28,7 @@ import (
 func TestProviderConstructorProperties(t *testing.T) {
 	resourceLimits := cloudprovider.ResourceLimiter{}
 
-	controller, stop := mustCreateTestController(t, testControllerConfig{})
+	controller, stop := mustCreateTestController(t)
 	defer stop()
 
 	provider, err := newProvider(ProviderName, &resourceLimits, controller)


### PR DESCRIPTION
This a rework of how the unit tests setup the controller and the objects under test. We previously accumulated three ways of setting up the tests - this change reduces that to using just one way, providing uniformity and consistency for all the tests.

The controller functions now return the `nodegroup` type rather than `cloudprovider.<type>` to make unit testing easier. The upper layers (i.e., the provider) convert the `nodegroup` to `cloudprovider.NodeGroup`. A `nodegroup` is a `cloudprovider.NodeGroup` so the overall change here is really small - it only changes the function signature.

Plus various drive-by fixes in the unit tests themselves to:
- remove unused fields
- fix-up some nil-pointer analysis highlighted by latest GoLand 2019.1 release
- increases the existing tests to also test using MachineDeployments where they previously didn't
