### PR TITLE
UPSTREAM: <carry>: openshift: disable MachineDeployment in normal operation

### DIFF
--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_provider.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_provider.go
@@ -17,7 +17,6 @@ limitations under the License.
 package openshiftmachineapi
 
 import (
-	"os"
 	"reflect"
 
 	clusterclientset "github.com/openshift/cluster-api/pkg/client/clientset_generated/clientset"
@@ -148,7 +147,7 @@ func BuildOpenShiftMachineAPI(opts config.AutoscalingOptions, do cloudprovider.N
 		klog.Fatalf("create cluster clientset failed: %v", err)
 	}
 
-	enableMachineDeployments := os.Getenv("OPENSHIFT_MACHINE_API_CLOUDPROVIDER_ENABLE_MACHINE_DEPLOYMENTS") != ""
+	enableMachineDeployments := false
 	controller, err := newMachineController(kubeclient, clusterclient, enableMachineDeployments)
 
 	if err != nil {


### PR DESCRIPTION
This disables the use and discovery of MachineDeployment's as a
resource that can be scaled. As OpenShift 4.1 does not deploy the
MachineDeployment CRD we explicitly disable trying to discover that
resource type in normal operation; the unit tests continue to test
with both MachineSet's and MachineDeployment's.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1700701.