### PR TITLE
[WIP] openshiftmachineapi: Scale From Zero - Proof of Concept

### DIFF
--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_provider.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_provider.go
@@ -60,7 +60,7 @@ func (p *provider) NodeGroups() []cloudprovider.NodeGroup {
 		return nil
 	}
 	for _, ng := range nodegroups {
-		klog.V(4).Infof("discovered node group: %s", ng.Debug())
+		// klog.Infof("discovered node group: %s", ng.Debug())
 		result = append(result, ng)
 	}
 	return result
@@ -79,6 +79,7 @@ func (p *provider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, 
 
 func (*provider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
+
 }
 
 func (*provider) GetAvailableMachineTypes() ([]string, error) {

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_scalableresource.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_scalableresource.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package openshiftmachineapi
 
+import (
+	"github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+	apiv1 "k8s.io/api/core/v1"
+)
+
 // scalableResource is a resource that can be scaled up and down by
 // adjusting its replica count field.
 type scalableResource interface {
@@ -43,4 +48,10 @@ type scalableResource interface {
 
 	// Replicas returns the current replica count of the resource
 	Replicas() int32
+
+	Labels() map[string]string
+
+	MachineClass() (*v1beta1.MachineClass, error)
+
+	Taints() []apiv1.Taint
 }

--- a/cluster-autoscaler/vendor/github.com/openshift/cluster-api/pkg/apis/machine/v1beta1/machineclass_types.go
+++ b/cluster-autoscaler/vendor/github.com/openshift/cluster-api/pkg/apis/machine/v1beta1/machineclass_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -42,7 +43,7 @@ type MachineClass struct {
 	// be provisioned when this class is used, to inform higher level
 	// automation (e.g. the cluster autoscaler).
 	// TODO(hardikdr) Add allocatable field once requirements are clear from autoscaler-clusterapi // integration topic.
-	// Capacity corev1.ResourceList `json:"capacity"`
+	Capacity corev1.ResourceList `json:"capacity"`
 
 	// How much capacity is actually allocatable on this machine.
 	// Must be equal to or less than the capacity, and when less
@@ -53,7 +54,7 @@ type MachineClass struct {
 	// be provisioned when this class is used, to inform higher level
 	// automation (e.g. the cluster autoscaler).
 	// TODO(hardikdr) Add allocatable field once requirements are clear from autoscaler-clusterapi // integration topic.
-	// Allocatable corev1.ResourceList `json:"allocatable"`
+	Allocatable corev1.ResourceList `json:"allocatable"`
 
 	// Provider-specific configuration to use during node creation.
 	ProviderSpec runtime.RawExtension `json:"providerSpec"`


### PR DESCRIPTION
This is a proof of concept that allows a `MachineSet | MachineDeployment` to scale from 0.

**DO NOT MERGE**.

This implements `<nodegroup>.TemplateNodeInfo()` for the openshiftmachineapi cloudprovider.

This function, when called, builds a representative `Node` object using information from the [synthetic] `MachineClass`. Everytime a nodegroup is constructed (in this PoC) I have injected/attached a `MachineClass` object to make the implementation genuine and generic. Ordinarily, this value would be present if we were already using machine classes.

In `TemplateNodeInfo()` we build a synthetic node and take the `Capacity` from the `MachineClass` object; the `Labels` and `Taints` are also dynamically derived.

```go
nodeName := fmt.Sprintf("%s-asg-%d", ng.Name(), rand.Int63())
node := apiv1.Node{
	ObjectMeta: metav1.ObjectMeta{
		Name:     nodeName,
		SelfLink: fmt.Sprintf("/api/v1/nodes/%s", nodeName),
		Labels:   map[string]string{},
	},
	Status: apiv1.NodeStatus{
		Capacity: apiv1.ResourceList{},
	},
}
node.Status.Capacity = machineClass.Capacity
node.Status.Allocatable = node.Status.Capacity
node.Status.Conditions = cloudprovider.BuildReadyConditions()
node.Spec.Taints = ng.scalableResource.Taints()
node.Labels = joinStringMaps(ng.scalableResource.Labels(), buildGenericLabels(nodeName))
```

To support scale from 0 only the following fields/values are required from a `MachineClass`:

```go
v1beta1.MachineClass{
	TypeMeta: metav1.TypeMeta{
		Kind: "MachineClass",
	},
	ObjectMeta: metav1.ObjectMeta{
		Name: "my-instance-type",
	},
	Capacity: map[apiv1.ResourceName]resource.Quantity{
		apiv1.ResourcePods:    *resource.NewQuantity(110, resource.DecimalSI),
		apiv1.ResourceCPU:     *resource.NewQuantity(2, resource.DecimalSI),
		gpu.ResourceNvidiaGPU: *resource.NewQuantity(0, resource.DecimalSI),
		apiv1.ResourceMemory:  *resource.NewQuantity(4096*1024*1024, resource.DecimalSI),
	},
}
```
Obviously the values `110`, `2`, `0`, and `4Gi` would be dynamic and different per 'instance' type.

I have changed the existing `MachineClass` object and exposed `Capacity` and `Allocatable` - these fields are currently commented out in the upstream [definition](https://github.com/kubernetes-sigs/cluster-api/blob/master/pkg/apis/cluster/v1alpha1/machineclass_types.go#L38):

```go
	// The total capacity available on this machine type (cpu/memory/disk).
	//
	// WARNING: It is up to the creator of the MachineClass to ensure that
	// this field is consistent with the underlying machine that will
	// be provisioned when this class is used, to inform higher level
	// automation (e.g. the cluster autoscaler).
	// TODO(hardikdr) Add allocatable field once requirements are clear from autoscaler-clusterapi // integration topic.
	// Capacity corev1.ResourceList `json:"capacity"`

	// How much capacity is actually allocatable on this machine.
	// Must be equal to or less than the capacity, and when less
	// indicates the resources reserved for system overhead.
	//
	// WARNING: It is up to the creator of the MachineClass to ensure that
	// this field is consistent with the underlying machine that will
	// be provisioned when this class is used, to inform higher level
	// automation (e.g. the cluster autoscaler).
	// TODO(hardikdr) Add allocatable field once requirements are clear from autoscaler-clusterapi // integration topic.
	// Allocatable corev1.ResourceList `json:"allocatable"`
```

TL;DR - if we switched to using machine classes then there is limited amount of information that is required to support scale from 0 - all of this should be readily available from the `ProviderSpec` information that is already present and used to construct machines today. I have tested this on AWS and with our kubemark actuator - in both cases we see scale from 0 working:

```console
$ kubectl get machinesets
NAME                                  DESIRED   CURRENT   READY   AVAILABLE   AGE
amcdermo-ca-wvbgq-worker-us-east-2a   0         0                             45m
amcdermo-ca-wvbgq-worker-us-east-2b   1         1         1       1           45m
amcdermo-ca-wvbgq-worker-us-east-2c   1         1         1       1           45m
```

Output from the autoscaler:

```console
I0426 10:23:11.033656    7596 machineapi_nodegroup.go:267] >>>>>>>> building a Node template from MachineClass "this-is-a-hack" <<<<<<<<

I0426 10:34:55.210595    7596 scale_up.go:422] Best option to resize: openshift-machine-api/amcdermo-ca-wvbgq-worker-us-east-2a
I0426 10:34:55.210619    7596 scale_up.go:426] Estimated 13 nodes needed in openshift-machine-api/amcdermo-ca-wvbgq-worker-us-east-2a
I0426 10:34:55.210628    7596 scale_up.go:431] Capping size to max cluster total size (10)
I0426 10:34:55.210651    7596 scale_up.go:528] Final scale-up plan: [{openshift-machine-api/amcdermo-ca-wvbgq-worker-us-east-2a 0->5 (max: 6)}]
I0426 10:34:55.210673    7596 scale_up.go:685] Scale-up: setting group openshift-machine-api/amcdermo-ca-wvbgq-worker-us-east-2a size to 5
```