### PR TITLE
UPSTREAM: <carry>: openshift: record max-nodes-total event

### DIFF
--- a/cluster-autoscaler/core/static_autoscaler.go
+++ b/cluster-autoscaler/core/static_autoscaler.go
@@ -295,7 +295,9 @@ func (a *StaticAutoscaler) RunOnce(currentTime time.Time) errors.AutoscalerError
 		klog.V(1).Info("No unschedulable pods")
 	} else if a.MaxNodesTotal > 0 && len(readyNodes) >= a.MaxNodesTotal {
 		scaleUpStatus.Result = status.ScaleUpNoOptionsAvailable
-		klog.V(1).Info("Max total nodes in cluster reached")
+		msg := "Max total nodes in cluster reached"
+		klog.V(1).Info(msg)
+		autoscalingContext.LogRecorder.Eventf(apiv1.EventTypeWarning, "MaxNodesTotalReached", msg)
 	} else if allPodsAreNew(unschedulablePodsToHelp, currentTime) {
 		// The assumption here is that these pods have been created very recently and probably there
 		// is more pods to come. In theory we could check the newest pod time but then if pod were created


### PR DESCRIPTION
This enables the e2e autoscaler tests [1] to verify that, when specified, `--max-nodes-total` is not exceeded when scaling out.

[1] openshift/cluster-api-actuator-pkg#77