### PR TITLE
UPSTREAM: <carry>: openshift: drop machine annotation linkage

### DIFF
--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup.go
@@ -29,7 +29,6 @@ import (
 
 const (
 	machineDeleteAnnotationKey = "machine.openshift.io/cluster-api-delete-machine"
-	machineAnnotationKey       = "machine.openshift.io/machine"
 	debugFormat                = "%s (min: %d, max: %d, replicas: %d)"
 )
 


### PR DESCRIPTION
This changes the mapping between a node and a machine to rely on the
presence of the ProviderID rather than the "machine" annotation
currently added by the nodelink-controller.

Note: this should not merge until we update the AWS, libvirt and
kubemark actuators - they should ensure that ProviderID is set, if not
already, on the machine object.