### PR TITLE
UPSTREAM: <carry>: openshift: use ProviderID for node lookup

### DIFF
--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	nodeProviderIDIndex = "openshiftmachineapi-nodeProviderIDIndex"
+	machineProviderIDIndex = "openshiftmachineapi-machineProviderIDIndex"
 )
 
 // machineController watches for Nodes, Machines, MachineSets and
@@ -53,9 +53,12 @@ type machineController struct {
 
 type machineSetFilterFunc func(machineSet *v1beta1.MachineSet) error
 
-func indexNodeByNodeProviderID(obj interface{}) ([]string, error) {
-	if node, ok := obj.(*apiv1.Node); ok {
-		return []string{node.Spec.ProviderID}, nil
+func indexMachineByProviderID(obj interface{}) ([]string, error) {
+	if machine, ok := obj.(*v1beta1.Machine); ok {
+		if machine.Spec.ProviderID != nil {
+			return []string{*machine.Spec.ProviderID}, nil
+		}
+		return []string{}, nil
 	}
 	return []string{}, nil
 }
@@ -155,7 +158,7 @@ func (c *machineController) run(stopCh <-chan struct{}) error {
 // node.Spec.ProviderID cannot be found or if the node has no machine
 // annotation. A DeepCopy() of the object is returned on success.
 func (c *machineController) findMachineByNodeProviderID(node *apiv1.Node) (*v1beta1.Machine, error) {
-	objs, err := c.nodeInformer.GetIndexer().ByIndex(nodeProviderIDIndex, node.Spec.ProviderID)
+	objs, err := c.machineInformer.Informer().GetIndexer().ByIndex(machineProviderIDIndex, node.Spec.ProviderID)
 	if err != nil {
 		return nil, err
 	}
@@ -167,16 +170,12 @@ func (c *machineController) findMachineByNodeProviderID(node *apiv1.Node) (*v1be
 		return nil, fmt.Errorf("internal error; expected len==1, got %v", n)
 	}
 
-	node, ok := objs[0].(*apiv1.Node)
+	machine, ok := objs[0].(*v1beta1.Machine)
 	if !ok {
-		return nil, fmt.Errorf("internal error; unexpected type %T", node)
+		return nil, fmt.Errorf("internal error; unexpected type %T", machine)
 	}
 
-	if machineName, found := node.Annotations[machineAnnotationKey]; found {
-		return c.findMachine(machineName)
-	}
-
-	return nil, nil
+	return machine.DeepCopy(), nil
 }
 
 // findNodeByNodeName find the Node object keyed by node.Name. Returns
@@ -247,12 +246,10 @@ func newMachineController(
 	nodeInformer := kubeInformerFactory.Core().V1().Nodes().Informer()
 	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{})
 
-	indexerFuncs := cache.Indexers{
-		nodeProviderIDIndex: indexNodeByNodeProviderID,
-	}
-
-	if err := nodeInformer.GetIndexer().AddIndexers(indexerFuncs); err != nil {
-		return nil, fmt.Errorf("cannot add indexers: %v", err)
+	if err := machineInformer.Informer().GetIndexer().AddIndexers(cache.Indexers{
+		machineProviderIDIndex: indexMachineByProviderID,
+	}); err != nil {
+		return nil, fmt.Errorf("cannot add machine indexer: %v", err)
 	}
 
 	return &machineController{

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller_test.go
@@ -447,7 +447,7 @@ func TestControllerFindMachineByNodeProviderID(t *testing.T) {
 	}
 }
 
-func TestControllerFindNodeByNodeName(t *testing.T) {
+func TestControllerFindNodeByProviderID(t *testing.T) {
 	testConfig := createMachineSetTestConfig(testNamespace, 1, 1, map[string]string{
 		nodeGroupMinSizeAnnotationKey: "1",
 		nodeGroupMaxSizeAnnotationKey: "10",
@@ -457,7 +457,7 @@ func TestControllerFindNodeByNodeName(t *testing.T) {
 	defer stop()
 
 	// Test #1: Verify known node can be found
-	node, err := controller.findNodeByNodeName(testConfig.nodes[0].Name)
+	node, err := controller.findNodeByProviderID(testConfig.nodes[0].Spec.ProviderID)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -466,7 +466,7 @@ func TestControllerFindNodeByNodeName(t *testing.T) {
 	}
 
 	// Test #2: Verify non-existent node cannot be found
-	node, err = controller.findNodeByNodeName(testConfig.nodes[0].Name + "non-existent")
+	node, err = controller.findNodeByProviderID(testConfig.nodes[0].Spec.ProviderID + "non-existent")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup.go
@@ -29,7 +29,6 @@ import (
 
 const (
 	machineDeleteAnnotationKey = "machine.openshift.io/cluster-api-delete-machine"
-	machineAnnotationKey       = "machine.openshift.io/machine"
 	debugFormat                = "%s (min: %d, max: %d, replicas: %d)"
 )
 


### PR DESCRIPTION
Reimplement `findNodeByNodeName()` as `findNodeByProviderID()`, using the `ProviderID` index.

Builds on top of #97.

