### PR TITLE
UPSTREAM: <carry>: openshift: prioritise search by Provider ID

### DIFF
--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller.go
@@ -301,6 +301,18 @@ func (c *machineController) machineSetNodeNames(machineSet *v1beta1.MachineSet) 
 	var nodes []string
 
 	for _, machine := range machines {
+		if machine.Spec.ProviderID != nil && *machine.Spec.ProviderID != "" {
+			// Prefer machine<=>node mapping using ProviderID
+			node, err := c.findNodeByProviderID(*machine.Spec.ProviderID)
+			if err != nil {
+				return nil, err
+			}
+			if node != nil {
+				nodes = append(nodes, node.Spec.ProviderID)
+				continue
+			}
+		}
+
 		if machine.Status.NodeRef == nil {
 			klog.V(4).Infof("Status.NodeRef of machine %q is currently nil", machine.Name)
 			continue

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup.go
@@ -96,7 +96,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*apiv1.Node) error {
 			return fmt.Errorf("node %q doesn't belong to node group %q", node.Spec.ProviderID, ng.Id())
 		}
 
-		machine, err := ng.machineController.findMachineByNodeProviderID(node)
+		machine, err := ng.machineController.findMachineByProviderID(node.Spec.ProviderID)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
 Change findMachineByNodeProviderID() to first match using ProviderID value. If there is no match (because actuator does not set the value on the machine object) then fallback to matching based on the "machine" annotation from the node object (should it exist). By falling back to the "machine" annotation on the node object we don't break compatibility with the behaviour in OpenShift 4.1.0.