### PR TITLE
UPSTREAM: <carry>: openshift: update criteria for returning a nodegroup

### DIFF
--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller.go
@@ -30,6 +30,7 @@ import (
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
+	"k8s.io/utils/pointer"
 )
 
 const (
@@ -365,7 +366,7 @@ func (c *machineController) machineSetNodeGroups() ([]*nodegroup, error) {
 		if err != nil {
 			return err
 		}
-		if ng.MaxSize()-ng.MinSize() > 0 {
+		if ng.MaxSize()-ng.MinSize() > 0 && pointer.Int32PtrDerefOr(machineSet.Spec.Replicas, 0) > 0 {
 			nodegroups = append(nodegroups, ng)
 		}
 		return nil
@@ -394,7 +395,7 @@ func (c *machineController) machineDeploymentNodeGroups() ([]*nodegroup, error) 
 			return nil, err
 		}
 		// add nodegroup iff it has the capacity to scale
-		if ng.MaxSize()-ng.MinSize() > 0 {
+		if ng.MaxSize()-ng.MinSize() > 0 && pointer.Int32PtrDerefOr(md.Spec.Replicas, 0) > 0 {
 			nodegroups = append(nodegroups, ng)
 		}
 	}

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller_test.go
@@ -738,19 +738,27 @@ func TestControllerNodeGroups(t *testing.T) {
 
 func TestControllerNodeGroupsNodeCount(t *testing.T) {
 	type testCase struct {
-		nodeGroups    int
-		nodesPerGroup int
+		nodeGroups            int
+		nodesPerGroup         int
+		expectedNodeGroups    int
+		expectedNodesPerGroup int
 	}
 
 	var testCases = []testCase{{
-		nodeGroups:    0,
-		nodesPerGroup: 0,
+		nodeGroups:            0,
+		nodesPerGroup:         0,
+		expectedNodeGroups:    0,
+		expectedNodesPerGroup: 0,
 	}, {
-		nodeGroups:    1,
-		nodesPerGroup: 0,
+		nodeGroups:            1,
+		nodesPerGroup:         0,
+		expectedNodeGroups:    0,
+		expectedNodesPerGroup: 0,
 	}, {
-		nodeGroups:    2,
-		nodesPerGroup: 10,
+		nodeGroups:            2,
+		nodesPerGroup:         10,
+		expectedNodeGroups:    2,
+		expectedNodesPerGroup: 10,
 	}}
 
 	test := func(t *testing.T, tc testCase, testConfigs []*testConfig) {
@@ -761,8 +769,8 @@ func TestControllerNodeGroupsNodeCount(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got := len(nodegroups); got != tc.nodeGroups {
-			t.Fatalf("expected %d, got %d", tc.nodeGroups, got)
+		if got := len(nodegroups); got != tc.expectedNodeGroups {
+			t.Fatalf("expected %d, got %d", tc.expectedNodeGroups, got)
 		}
 
 		for i := range nodegroups {
@@ -770,8 +778,8 @@ func TestControllerNodeGroupsNodeCount(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if got := len(nodes); got != tc.nodesPerGroup {
-				t.Fatalf("expected %d, got %d", tc.nodesPerGroup, got)
+			if got := len(nodes); got != tc.expectedNodesPerGroup {
+				t.Fatalf("expected %d, got %d", tc.expectedNodesPerGroup, got)
 			}
 		}
 	}


### PR DESCRIPTION
We previously only considered a MachineSet or MachineDeployment
suitable for scaling if it had positive scaling bounds.

For example:

    annotations:
      machine.openshift.io/cluster-api-autoscaler-node-group-min-size: "1"
      machine.openshift.io/cluster-api-autoscaler-node-group-max-size: "6"

On us-west-2 we have:

    $ kubectl get machinesets
    NAME                                  DESIRED   CURRENT   READY   AVAILABLE   AGE
    amcdermo-ca-5ws2b-worker-us-west-2a   1         1         1       1           4h23m
    amcdermo-ca-5ws2b-worker-us-west-2b   1         1         1       1           4h23m
    amcdermo-ca-5ws2b-worker-us-west-2c   1         1         1       1           4h23m
    amcdermo-ca-5ws2b-worker-us-west-2d   0         0                             4h23m

but the autoscaler will fail to scale up any of these because the last
machineset has a replica count of 0. This change modifies the criteria
for where we return a nodegroup (i.e., machine set) to must have:
- positive scaling bounds, and
- the underlying resource must have a replica count that is > 0.