### PR TITLE
[WIP] UPSTREAM: <carry>: openshift: Implement scale from zero

### DIFF
--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_machinedeployment.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_machinedeployment.go
@@ -21,8 +21,11 @@ import (
 	"path"
 	"time"
 
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/utils/pointer"
 )
 
@@ -133,4 +136,32 @@ func newMachineDeploymentScalableResource(controller *machineController, machine
 		maxSize:           maxSize,
 		minSize:           minSize,
 	}, nil
+}
+
+func (r machineDeploymentScalableResource) Taints() []apiv1.Taint {
+	return r.machineDeployment.Spec.Template.Spec.Taints
+}
+
+func (r machineDeploymentScalableResource) Labels() map[string]string {
+	return cloudprovider.JoinStringMaps(r.machineDeployment.Labels, r.machineDeployment.Spec.Template.Labels, r.machineDeployment.Spec.Template.Spec.Labels)
+}
+
+func (r machineDeploymentScalableResource) CanScaleFromZero() bool {
+	return scaleFromZeroEnabled(r.machineDeployment.Annotations)
+}
+
+func (r machineDeploymentScalableResource) InstanceCPUCapacity() (resource.Quantity, error) {
+	return parseCPUCapacity(r.machineDeployment.Annotations)
+}
+
+func (r machineDeploymentScalableResource) InstanceMemoryCapacity() (resource.Quantity, error) {
+	return parseMemoryCapacity(r.machineDeployment.Annotations)
+}
+
+func (r machineDeploymentScalableResource) InstancePodCapacity() (resource.Quantity, error) {
+	return parsePodCapacity(r.machineDeployment.Annotations)
+}
+
+func (r machineDeploymentScalableResource) InstanceGPUCapacity() (resource.Quantity, error) {
+	return parseGPUCapacity(r.machineDeployment.Annotations)
 }

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_machineset.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_machineset.go
@@ -21,8 +21,11 @@ import (
 	"path"
 	"time"
 
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/utils/pointer"
 )
 
@@ -118,4 +121,32 @@ func newMachineSetScalableResource(controller *machineController, machineSet *Ma
 		maxSize:    maxSize,
 		minSize:    minSize,
 	}, nil
+}
+
+func (r machineSetScalableResource) Labels() map[string]string {
+	return cloudprovider.JoinStringMaps(r.machineSet.Labels, r.machineSet.Spec.Template.Labels, r.machineSet.Spec.Template.Spec.Labels)
+}
+
+func (r machineSetScalableResource) Taints() []apiv1.Taint {
+	return r.machineSet.Spec.Template.Spec.Taints
+}
+
+func (r machineSetScalableResource) CanScaleFromZero() bool {
+	return scaleFromZeroEnabled(r.machineSet.Annotations)
+}
+
+func (r machineSetScalableResource) InstanceCPUCapacity() (resource.Quantity, error) {
+	return parseCPUCapacity(r.machineSet.Annotations)
+}
+
+func (r machineSetScalableResource) InstanceMemoryCapacity() (resource.Quantity, error) {
+	return parseMemoryCapacity(r.machineSet.Annotations)
+}
+
+func (r machineSetScalableResource) InstancePodCapacity() (resource.Quantity, error) {
+	return parsePodCapacity(r.machineSet.Annotations)
+}
+
+func (r machineSetScalableResource) InstanceGPUCapacity() (resource.Quantity, error) {
+	return parseGPUCapacity(r.machineSet.Annotations)
 }

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup_test.go
@@ -168,8 +168,10 @@ func TestNodeGroupNewNodeGroupConstructor(t *testing.T) {
 			t.Errorf("expected %q, got %q", expectedDebug, ng.Debug())
 		}
 
-		if _, err := ng.TemplateNodeInfo(); err != cloudprovider.ErrNotImplemented {
-			t.Error("expected error")
+		if ng.scalableResource.CanScaleFromZero() {
+			if _, err := ng.TemplateNodeInfo(); err != cloudprovider.ErrNotImplemented {
+				t.Error("expected error")
+			}
 		}
 
 		if exists := ng.Exist(); !exists {

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_scalableresource.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_scalableresource.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package openshiftmachineapi
 
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
 // scalableResource is a resource that can be scaled up and down by
 // adjusting its replica count field.
 type scalableResource interface {
@@ -46,4 +51,12 @@ type scalableResource interface {
 
 	// MarkMachineForDeletion marks machine for deletion
 	MarkMachineForDeletion(machine *Machine) error
+
+	Labels() map[string]string
+	Taints() []apiv1.Taint
+	CanScaleFromZero() bool
+	InstanceCPUCapacity() (resource.Quantity, error)
+	InstanceMemoryCapacity() (resource.Quantity, error)
+	InstancePodCapacity() (resource.Quantity, error)
+	InstanceGPUCapacity() (resource.Quantity, error)
 }


### PR DESCRIPTION
This allows a Machine{Set,Deployment} to scale up/down from 0,
providing the following annotations are set:

```yaml
apiVersion: v1
items:
- apiVersion: machine.openshift.io/v1beta1
  kind: MachineSet
  metadata:
    annotations:
      machine.openshift.io/cluster-api-autoscaler-node-group-min-size: "0"
      machine.openshift.io/cluster-api-autoscaler-node-group-max-size: "6"
      machine.openshift.io/instance-cpu-capacity: "2"
      machine.openshift.io/instance-memory-capacity: 8G
      machine.openshift.io/instance-pod-capacity: "100"
      machine.openshift.io/scale-from-zero: "true"
```