### PR TITLE
UPSTREAM: <carry>: openshift: reference k8s.io/api/core/v1 as corev1

### DIFF
--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller.go
@@ -23,7 +23,7 @@ import (
 	clusterclient "github.com/openshift/cluster-api/pkg/client/clientset_generated/clientset"
 	clusterinformers "github.com/openshift/cluster-api/pkg/client/informers_generated/externalversions"
 	machinev1beta1 "github.com/openshift/cluster-api/pkg/client/informers_generated/externalversions/machine/v1beta1"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kubeinformers "k8s.io/client-go/informers"
@@ -66,7 +66,7 @@ func indexMachineByProviderID(obj interface{}) ([]string, error) {
 }
 
 func indexNodeByProviderID(obj interface{}) ([]string, error) {
-	if node, ok := obj.(*apiv1.Node); ok {
+	if node, ok := obj.(*corev1.Node); ok {
 		if node.Spec.ProviderID != "" {
 			return []string{node.Spec.ProviderID}, nil
 		}
@@ -204,7 +204,7 @@ func (c *machineController) findMachineByProviderID(providerID string) (*v1beta1
 // findNodeByNodeName finds the Node object keyed by name.. Returns
 // nil if it cannot be found. A DeepCopy() of the object is returned
 // on success.
-func (c *machineController) findNodeByNodeName(name string) (*apiv1.Node, error) {
+func (c *machineController) findNodeByNodeName(name string) (*corev1.Node, error) {
 	item, exists, err := c.nodeInformer.GetIndexer().GetByKey(name)
 	if err != nil {
 		return nil, err
@@ -214,7 +214,7 @@ func (c *machineController) findNodeByNodeName(name string) (*apiv1.Node, error)
 		return nil, nil
 	}
 
-	node, ok := item.(*apiv1.Node)
+	node, ok := item.(*corev1.Node)
 	if !ok {
 		return nil, fmt.Errorf("internal error; unexpected type %T", node)
 	}
@@ -382,7 +382,7 @@ func (c *machineController) machineDeploymentNodeGroups() ([]*nodegroup, error) 
 		return nil, nil
 	}
 
-	machineDeployments, err := c.machineDeploymentInformer.Lister().MachineDeployments(apiv1.NamespaceAll).List(labels.Everything())
+	machineDeployments, err := c.machineDeploymentInformer.Lister().MachineDeployments(corev1.NamespaceAll).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
@@ -416,7 +416,7 @@ func (c *machineController) nodeGroups() ([]*nodegroup, error) {
 	return append(machineSets, machineDeployments...), nil
 }
 
-func (c *machineController) nodeGroupForNode(node *apiv1.Node) (*nodegroup, error) {
+func (c *machineController) nodeGroupForNode(node *corev1.Node) (*nodegroup, error) {
 	machine, err := c.findMachineByProviderID(node.Spec.ProviderID)
 	if err != nil {
 		return nil, err
@@ -476,7 +476,7 @@ func (c *machineController) nodeGroupForNode(node *apiv1.Node) (*nodegroup, erro
 // findNodeByProviderID find the Node object keyed by provideID.
 // Returns nil if it cannot be found. A DeepCopy() of the object is
 // returned on success.
-func (c *machineController) findNodeByProviderID(providerID string) (*apiv1.Node, error) {
+func (c *machineController) findNodeByProviderID(providerID string) (*corev1.Node, error) {
 	objs, err := c.nodeInformer.GetIndexer().ByIndex(nodeProviderIDIndex, providerID)
 	if err != nil {
 		return nil, err
@@ -489,7 +489,7 @@ func (c *machineController) findNodeByProviderID(providerID string) (*apiv1.Node
 		return nil, fmt.Errorf("internal error; expected len==1, got %v", n)
 	}
 
-	node, ok := objs[0].(*apiv1.Node)
+	node, ok := objs[0].(*corev1.Node)
 	if !ok {
 		return nil, fmt.Errorf("internal error; unexpected type %T", node)
 	}

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	fakeclusterapi "github.com/openshift/cluster-api/pkg/client/clientset_generated/clientset/fake"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -42,7 +42,7 @@ type testConfig struct {
 	machineDeployment *v1beta1.MachineDeployment
 	machineSet        *v1beta1.MachineSet
 	machines          []*v1beta1.Machine
-	nodes             []*apiv1.Node
+	nodes             []*corev1.Node
 }
 
 type testSpec struct {
@@ -131,7 +131,7 @@ func createTestConfigs(specs ...testSpec) []*testConfig {
 	for i, spec := range specs {
 		config := &testConfig{
 			spec:     &specs[i],
-			nodes:    make([]*apiv1.Node, spec.nodeCount),
+			nodes:    make([]*corev1.Node, spec.nodeCount),
 			machines: make([]*v1beta1.Machine, spec.nodeCount),
 		}
 
@@ -192,8 +192,8 @@ func createTestConfigs(specs ...testSpec) []*testConfig {
 // makeLinkedNodeAndMachine creates a node and machine. The machine
 // has its NodeRef set to the new node and the new machine's owner
 // reference is set to owner.
-func makeLinkedNodeAndMachine(i int, namespace string, owner v1.OwnerReference) (*apiv1.Node, *v1beta1.Machine) {
-	node := &apiv1.Node{
+func makeLinkedNodeAndMachine(i int, namespace string, owner v1.OwnerReference) (*corev1.Node, *v1beta1.Machine) {
+	node := &corev1.Node{
 		TypeMeta: v1.TypeMeta{
 			Kind: "Node",
 		},
@@ -203,7 +203,7 @@ func makeLinkedNodeAndMachine(i int, namespace string, owner v1.OwnerReference) 
 				machineAnnotationKey: fmt.Sprintf("%s/%s-%s-machine-%d", namespace, namespace, owner.Name, i),
 			},
 		},
-		Spec: apiv1.NodeSpec{
+		Spec: corev1.NodeSpec{
 			ProviderID: fmt.Sprintf("%s-%s-nodeid-%d", namespace, owner.Name, i),
 		},
 	}
@@ -225,7 +225,7 @@ func makeLinkedNodeAndMachine(i int, namespace string, owner v1.OwnerReference) 
 			ProviderID: pointer.StringPtr(fmt.Sprintf("%s-%s-nodeid-%d", namespace, owner.Name, i)),
 		},
 		Status: v1beta1.MachineStatus{
-			NodeRef: &apiv1.ObjectReference{
+			NodeRef: &corev1.ObjectReference{
 				Kind: node.Kind,
 				Name: node.Name,
 			},

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	machinev1beta1 "github.com/openshift/cluster-api/pkg/client/clientset_generated/clientset/typed/machine/v1beta1"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/klog"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
@@ -86,7 +86,7 @@ func (ng *nodegroup) IncreaseSize(delta int) error {
 // either on failure or if the given node doesn't belong to this node
 // group. This function should wait until node group size is updated.
 // Implementation required.
-func (ng *nodegroup) DeleteNodes(nodes []*apiv1.Node) error {
+func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 	// Step 1: Verify all nodes belong to this node group.
 	for _, node := range nodes {
 		actualNodeGroup, err := ng.machineController.nodeGroupForNode(node)

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_provider.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_provider.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 
 	clusterclientset "github.com/openshift/cluster-api/pkg/client/clientset_generated/clientset"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
@@ -65,7 +65,7 @@ func (p *provider) NodeGroups() []cloudprovider.NodeGroup {
 	return result
 }
 
-func (p *provider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+func (p *provider) NodeGroupForNode(node *corev1.Node) (cloudprovider.NodeGroup, error) {
 	ng, err := p.controller.nodeGroupForNode(node)
 	if err != nil {
 		return nil, err
@@ -88,7 +88,7 @@ func (*provider) NewNodeGroup(
 	machineType string,
 	labels map[string]string,
 	systemLabels map[string]string,
-	taints []apiv1.Taint,
+	taints []corev1.Taint,
 	extraResources map[string]resource.Quantity,
 ) (cloudprovider.NodeGroup, error) {
 	return nil, cloudprovider.ErrNotImplemented
@@ -103,7 +103,7 @@ func (p *provider) Refresh() error {
 }
 
 // GetInstanceID gets the instance ID for the specified node.
-func (p *provider) GetInstanceID(node *apiv1.Node) string {
+func (p *provider) GetInstanceID(node *corev1.Node) string {
 	return node.Spec.ProviderID
 }
 

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_provider_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 )
@@ -79,7 +79,7 @@ func TestProviderConstructorProperties(t *testing.T) {
 		t.Errorf("expected 0, got %v", len(nodegroups))
 	}
 
-	ng, err := provider.NodeGroupForNode(&apiv1.Node{
+	ng, err := provider.NodeGroupForNode(&corev1.Node{
 		TypeMeta: v1.TypeMeta{
 			Kind: "Node",
 		},


### PR DESCRIPTION
This is largely to be consistent with other usages (in the community)
but really to be at parity with the upstream PR [1] that uses this
import alias already. This also makes it easier to backport changes
made from openshift/autoscaler into upstream.

[1] https://github.com/kubernetes/autoscaler/pull/1866