### PR TITLE
UPSTREAM: <carry>: openshift: Extend makefile with 'make goimports' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,3 +134,7 @@ fmt: ## Go fmt your code
 .PHONY: vet
 vet: ## Go fmt your code
 	hack/go-vet.sh ./cluster-autoscaler/cloudprovider/openshiftmachineapi
+
+.PHONY: goimports
+goimports: ## Go fmt your code
+	hack/goimports.sh ./cluster-autoscaler/cloudprovider/openshiftmachineapi

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	fakeclusterapi "github.com/openshift/cluster-api/pkg/client/clientset_generated/clientset/fake"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup_test.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/utils/pointer"
 )

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_provider_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 )
 

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_utils_test.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_utils_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (

--- a/hack/goimports.sh
+++ b/hack/goimports.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+REPO_NAME=$(basename "${PWD}")
+if [ "$IS_CONTAINER" != "" ]; then
+  for TARGET in "${@}"; do
+    find "${TARGET}" -name '*.go' ! -path '*/vendor/*' ! -path '*/.build/*' -exec goimports -w {} \+
+  done
+  git diff --exit-code
+else
+  docker run -it --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/go/src/sigs.k8s.io/${REPO_NAME}:z" \
+    --workdir "/go/src/sigs.k8s.io/${REPO_NAME}" \
+    openshift/origin-release:golang-1.12 \
+    ./hack/goimports.sh "${@}"
+fi


### PR DESCRIPTION
So the target can be run in CI and fail in case files are not properly goimport formated.