### PR TITLE
UPSTREAM: <carry>: openshift: fix nodeset comparator

### DIFF
--- a/cluster-autoscaler/processors/nodegroupset/openshiftmachineapi_compare_nodegroups_test.go
+++ b/cluster-autoscaler/processors/nodegroupset/openshiftmachineapi_compare_nodegroups_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodegroupset
+
+import (
+	"testing"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
+	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"
+)
+
+func TestOpenShiftIdenticalNodesSimilar(t *testing.T) {
+	n1 := BuildTestNode("node1", 1000, 2000)
+	n2 := BuildTestNode("node2", 1000, 2000)
+	checkNodesSimilar(t, n1, n2, IsOpenShiftMachineApiNodeInfoSimilar, true)
+}
+
+func TestOpenShiftNodesSimilarVariousRequirements(t *testing.T) {
+	n1 := BuildTestNode("node1", 1000, 2000)
+
+	// Different CPU capacity
+	n2 := BuildTestNode("node2", 1000, 2000)
+	n2.Status.Capacity[apiv1.ResourceCPU] = *resource.NewMilliQuantity(1001, resource.DecimalSI)
+	checkNodesSimilar(t, n1, n2, IsOpenShiftMachineApiNodeInfoSimilar, false)
+
+	// Same CPU capacity, but slightly different allocatable
+	n3 := BuildTestNode("node3", 1000, 2000)
+	n3.Status.Allocatable[apiv1.ResourceCPU] = *resource.NewMilliQuantity(999, resource.DecimalSI)
+	checkNodesSimilar(t, n1, n3, IsOpenShiftMachineApiNodeInfoSimilar, true)
+
+	// Same CPU capacity, significantly different allocatable
+	n4 := BuildTestNode("node4", 1000, 2000)
+	n4.Status.Allocatable[apiv1.ResourceCPU] = *resource.NewMilliQuantity(500, resource.DecimalSI)
+	checkNodesSimilar(t, n1, n4, IsOpenShiftMachineApiNodeInfoSimilar, false)
+
+	// One with GPU, one without
+	n5 := BuildTestNode("node5", 1000, 2000)
+	n5.Status.Capacity[gpu.ResourceNvidiaGPU] = *resource.NewQuantity(1, resource.DecimalSI)
+	n5.Status.Allocatable[gpu.ResourceNvidiaGPU] = n5.Status.Capacity[gpu.ResourceNvidiaGPU]
+	checkNodesSimilar(t, n1, n5, IsOpenShiftMachineApiNodeInfoSimilar, false)
+}
+
+func TestOpenShiftNodesSimilarVariousRequirementsAndPods(t *testing.T) {
+	n1 := BuildTestNode("node1", 1000, 2000)
+	p1 := BuildTestPod("pod1", 500, 1000)
+	p1.Spec.NodeName = "node1"
+
+	// Different allocatable, but same free
+	n2 := BuildTestNode("node2", 1000, 2000)
+	n2.Status.Allocatable[apiv1.ResourceCPU] = *resource.NewMilliQuantity(500, resource.DecimalSI)
+	n2.Status.Allocatable[apiv1.ResourceMemory] = *resource.NewQuantity(1000, resource.DecimalSI)
+	checkNodesSimilarWithPods(t, n1, n2, []*apiv1.Pod{p1}, []*apiv1.Pod{}, IsOpenShiftMachineApiNodeInfoSimilar, false)
+
+	// Same requests of pods
+	n3 := BuildTestNode("node3", 1000, 2000)
+	p3 := BuildTestPod("pod3", 500, 1000)
+	p3.Spec.NodeName = "node3"
+	checkNodesSimilarWithPods(t, n1, n3, []*apiv1.Pod{p1}, []*apiv1.Pod{p3}, IsOpenShiftMachineApiNodeInfoSimilar, true)
+
+	// Similar allocatable, similar pods
+	n4 := BuildTestNode("node4", 1000, 2000)
+	n4.Status.Allocatable[apiv1.ResourceCPU] = *resource.NewMilliQuantity(999, resource.DecimalSI)
+	p4 := BuildTestPod("pod4", 501, 1001)
+	p4.Spec.NodeName = "node4"
+	checkNodesSimilarWithPods(t, n1, n4, []*apiv1.Pod{p1}, []*apiv1.Pod{p4}, IsOpenShiftMachineApiNodeInfoSimilar, true)
+}
+
+func TestOpenShiftNodesSimilarVariousLabels(t *testing.T) {
+	n1 := BuildTestNode("node1", 1000, 2000)
+	n1.ObjectMeta.Labels["test-label"] = "test-value"
+	n1.ObjectMeta.Labels["character"] = "winnie the pooh"
+
+	n2 := BuildTestNode("node2", 1000, 2000)
+	n2.ObjectMeta.Labels["test-label"] = "test-value"
+
+	// Missing character label
+	checkNodesSimilar(t, n1, n2, IsOpenShiftMachineApiNodeInfoSimilar, false)
+
+	n2.ObjectMeta.Labels["character"] = "winnie the pooh"
+	checkNodesSimilar(t, n1, n2, IsOpenShiftMachineApiNodeInfoSimilar, true)
+
+	// Different hostname labels shouldn't matter
+	n1.ObjectMeta.Labels[apiv1.LabelHostname] = "node1"
+	n2.ObjectMeta.Labels[apiv1.LabelHostname] = "node2"
+	checkNodesSimilar(t, n1, n2, IsOpenShiftMachineApiNodeInfoSimilar, true)
+
+	// Different zone shouldn't matter either
+	n1.ObjectMeta.Labels[apiv1.LabelZoneFailureDomain] = "mars-olympus-mons1-b"
+	n2.ObjectMeta.Labels[apiv1.LabelZoneFailureDomain] = "us-houston1-a"
+	checkNodesSimilar(t, n1, n2, IsOpenShiftMachineApiNodeInfoSimilar, true)
+
+	// Different beta.kubernetes.io/fluentd-ds-ready should not matter
+	n1.ObjectMeta.Labels["beta.kubernetes.io/fluentd-ds-ready"] = "true"
+	n2.ObjectMeta.Labels["beta.kubernetes.io/fluentd-ds-ready"] = "false"
+	checkNodesSimilar(t, n1, n2, IsOpenShiftMachineApiNodeInfoSimilar, true)
+
+	n1.ObjectMeta.Labels["beta.kubernetes.io/fluentd-ds-ready"] = "true"
+	delete(n2.ObjectMeta.Labels, "beta.kubernetes.io/fluentd-ds-ready")
+	checkNodesSimilar(t, n1, n2, IsOpenShiftMachineApiNodeInfoSimilar, true)
+}
+
+func TestOpenShiftNodesSimilarVariousMemoryRequirements(t *testing.T) {
+	n1 := BuildTestNode("node1", 1000, MaxMemoryDifferenceInKiloBytes)
+
+	// Different memory capacity within tolerance
+	n2 := BuildTestNode("node2", 1000, MaxMemoryDifferenceInKiloBytes)
+	n2.Status.Capacity[apiv1.ResourceMemory] = *resource.NewQuantity(2*MaxMemoryDifferenceInKiloBytes, resource.DecimalSI)
+	checkNodesSimilar(t, n1, n2, IsOpenShiftMachineApiNodeInfoSimilar, true)
+
+	// Different memory capacity exceeds tolerance
+	n3 := BuildTestNode("node3", 1000, MaxMemoryDifferenceInKiloBytes)
+	n3.Status.Capacity[apiv1.ResourceMemory] = *resource.NewQuantity(2*MaxMemoryDifferenceInKiloBytes+1, resource.DecimalSI)
+	checkNodesSimilar(t, n1, n3, IsOpenShiftMachineApiNodeInfoSimilar, false)
+}


### PR DESCRIPTION
When comparing memory capacity differences we should specifically only
tolerate differences in `apiv1.ResourceMemory` types.

In https://github.com/openshift/kubernetes-autoscaler/pull/113 we
inadvertently did that for all capacity types. To mitigate against
that mistake I've copied the existing comparator tests and now ensure
that they run against the IsOpenShiftMachineApiNodeInfoSimilar
function, additionally adding a test that verifies the behaviour
introduced https://github.com/openshift/kubernetes-autoscaler/pull/113.

With this change I still see the split against multiple node groups:

```console
I0906 15:29:46.946026   11483 scale_up.go:426] Estimated 30 nodes needed in openshift-machine-api/e2e-bcf76-w-0
I0906 15:29:46.946432   11483 scale_up.go:521] Splitting scale-up between 10 similar node groups: {openshift-machine-api/e2e-bcf76-w-0, openshift-machine-api/e2e-bcf76-w-9, openshift-machine-api/e2e-bcf76-w-2, openshift-machine-api/e2e-bcf76-w-5, openshift-machine-api/e2e-bcf76-w-1, openshift-machine-api/e2e-bcf76-w-3, openshift-machine-api/e2e-bcf76-w-6, openshift-machine-api/e2e-bcf76-w-7, openshift-machine-api/e2e-bcf76-w-8, openshift-machine-api/e2e-bcf76-w-4}
I0906 15:29:46.946453   11483 scale_up.go:529] Final scale-up plan: [{openshift-machine-api/e2e-bcf76-w-0 1->4 (max: 10)} {openshift-machine-api/e2e-bcf76-w-9 1->4 (max: 10)} {openshift-machine-api/e2e-bcf76-w-2 1->4 (max: 10)} {openshift-machine-api/e2e-bcf76-w-5 1->4 (max: 10)} {openshift-machine-api/e2e-bcf76-w-1 1->4 (max: 10)} {openshift-machine-api/e2e-bcf76-w-3 1->4 (max: 10)} {openshift-machine-api/e2e-bcf76-w-6 1->4 (max: 10)} {openshift-machine-api/e2e-bcf76-w-7 1->4 (max: 10)} {openshift-machine-api/e2e-bcf76-w-8 1->4 (max: 10)} {openshift-machine-api/e2e-bcf76-w-4 1->4 (max: 10)}]
```

```console
$ oc get machinesets
NAME                               DESIRED   CURRENT   READY   AVAILABLE   AGE
amcdermo-jlmsr-worker-centralus1   1         1         1       1           2d4h
amcdermo-jlmsr-worker-centralus2   1         1         1       1           2d4h
amcdermo-jlmsr-worker-centralus3   1         1         1       1           2d4h
e2e-bcf76-w-0                      4         4         1       1           16m
e2e-bcf76-w-1                      4         4         1       1           16m
e2e-bcf76-w-2                      4         4         1       1           16m
e2e-bcf76-w-3                      4         4         1       1           16m
e2e-bcf76-w-4                      4         4         1       1           16m
e2e-bcf76-w-5                      4         4         1       1           16m
e2e-bcf76-w-6                      4         4         1       1           16m
e2e-bcf76-w-7                      4         4         1       1           16m
e2e-bcf76-w-8                      4         4         1       1           16m
e2e-bcf76-w-9                      4         4         1       1           16m
```