### PR TITLE
Bug 1801254: UPSTREAM: <carry>: openshift: Let Nodes() return the list of all machines

### DIFF
--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_machinedeployment.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_machinedeployment.go
@@ -61,11 +61,11 @@ func (r machineDeploymentScalableResource) Nodes() ([]string, error) {
 
 	if err := r.controller.filterAllMachineSets(func(machineSet *v1beta1.MachineSet) error {
 		if machineSetIsOwnedByMachineDeployment(machineSet, r.machineDeployment) {
-			names, err := r.controller.machineSetNodeNames(machineSet)
+			providerIDs, err := r.controller.machineSetProviderIDs(machineSet)
 			if err != nil {
 				return err
 			}
-			result = append(result, names...)
+			result = append(result, providerIDs...)
 		}
 		return nil
 	}); err != nil {

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_machineset.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_machineset.go
@@ -57,7 +57,7 @@ func (r machineSetScalableResource) Namespace() string {
 }
 
 func (r machineSetScalableResource) Nodes() ([]string, error) {
-	return r.controller.machineSetNodeNames(r.machineSet)
+	return r.controller.machineSetProviderIDs(r.machineSet)
 }
 
 func (r machineSetScalableResource) Replicas() int32 {

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup.go
@@ -191,6 +191,7 @@ func (ng *nodegroup) Debug() string {
 }
 
 // Nodes returns a list of all nodes that belong to this node group.
+// This includes instances that might have not become a kubernetes node yet.
 func (ng *nodegroup) Nodes() ([]cloudprovider.Instance, error) {
 	nodes, err := ng.scalableResource.Nodes()
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_scalableresource.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_scalableresource.go
@@ -34,7 +34,7 @@ type scalableResource interface {
 	// Namespace returns the namespace the resource is in
 	Namespace() string
 
-	// Nodes returns a list of all nodes that belong to this
+	// Nodes returns a list of all machines that already have or should become nodes that belong to this
 	// resource
 	Nodes() ([]string, error)
 


### PR DESCRIPTION
The autoscaler expects provider implementations nodeGroups to implement the Nodes() function to return the number of instances belonging to the group regardless of they have become a kubernetes node or not.
This information is then used for instance to realise about unregistered nodes https://github.com/kubernetes/autoscaler/blob/bf3a9fb52e3214dff0bea5ef2b97f17ad00a7702/cluster-autoscaler/clusterstate/clusterstate.go#L307-L311

Related https://github.com/kubernetes/autoscaler/pull/2815