### PR TITLE
VPA: symlink key/cert to secret volume

### DIFF
--- a/vertical-pod-autoscaler/Dockerfile.openshift
+++ b/vertical-pod-autoscaler/Dockerfile.openshift
@@ -11,4 +11,8 @@ COPY --from=builder \
     /go/src/k8s.io/autoscaler/vertical-pod-autoscaler/updater \
     /go/src/k8s.io/autoscaler/vertical-pod-autoscaler/recommender \
     /usr/bin/
+RUN mkdir /etc/tls-certs && \
+    ln -sf /data/tls-certs/tls.key /etc/tls-certs/serverKey.pem && \
+    ln -sf /data/tls-certs/tls.crt /etc/tls-certs/serverCert.pem && \
+    ln -sf /data/tls-ca-certs/service-ca.crt /etc/tls-certs/caCert.pem
 LABEL summary="Vertical Pod Autoscaler for OpenShift and Kubernetes"

--- a/vertical-pod-autoscaler/Dockerfile.rhel7
+++ b/vertical-pod-autoscaler/Dockerfile.rhel7
@@ -11,4 +11,8 @@ COPY --from=builder \
     /go/src/k8s.io/autoscaler/vertical-pod-autoscaler/updater \
     /go/src/k8s.io/autoscaler/vertical-pod-autoscaler/recommender \
     /usr/bin/
+RUN mkdir /etc/tls-certs && \
+    ln -sf /data/tls-certs/tls.key /etc/tls-certs/serverKey.pem && \
+    ln -sf /data/tls-certs/tls.crt /etc/tls-certs/serverCert.pem && \
+    ln -sf /data/tls-ca-certs/service-ca.crt /etc/tls-certs/caCert.pem
 LABEL summary="Vertical Pod Autoscaler for OpenShift and Kubernetes"


### PR DESCRIPTION
Because the admission controller expects the TLS key/cet pair
files to be named differently than how they are named by the
OpenShift `service-ca` controller, we create symlinks in the
container so that the admission controller will find them in
the right place.

This change is required for https://github.com/openshift/vertical-pod-autoscaler-operator/pull/9