### PR TITLE
BUG 1804738: Ensure DeleteNodes doesn't delete a node twice

### DIFF
--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_nodegroup.go
@@ -94,6 +94,10 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 			return nil
 		}
 
+		if actualNodeGroup == nil {
+			return fmt.Errorf("no node group found for node %q", node.Spec.ProviderID)
+		}
+
 		if actualNodeGroup.Id() != ng.Id() {
 			return fmt.Errorf("node %q doesn't belong to node group %q", node.Spec.ProviderID, ng.Id())
 		}
@@ -121,6 +125,11 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 		}
 
 		machine = machine.DeepCopy()
+
+		if !machine.GetDeletionTimestamp().IsZero() {
+			// The machine for this node is already being deleted
+			continue
+		}
 
 		if machine.Annotations == nil {
 			machine.Annotations = map[string]string{}


### PR DESCRIPTION
I have seen the autoscaler call `DeleteNodes` several times while a node it is trying to delete has not been fully deleted (finalizer still present). Currently, it does not check if the node's Machine has already been deleted and blindly reduces the size of the node group by 1 on every call to `DeleteNodes`

This PR adds a check, so that if a node's `Machine` already has a deletion timestamp, we do not decrease the size of the node group any further

I've added a test that calls the `DeleteNodes` twice and expects the node group size to not decrease on the second call, which passes with the fix, and fails without