### PR TITLE
UPSTREAM: <carry>: openshift: enable machineapi_provider_test

### DIFF
--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_provider_test.go
@@ -1,5 +1,3 @@
-// +build !linux
-
 /*
 Copyright 2019 The Kubernetes Authors.
 


### PR DESCRIPTION
This was missed in the review of https://github.com/openshift/kubernetes-autoscaler/pull/130