### PR TITLE
Discover api version

### DIFF
--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_provider.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_provider.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -144,14 +145,18 @@ func BuildOpenShiftMachineAPI(opts config.AutoscalingOptions, do cloudprovider.N
 		klog.Fatalf("could not generate dynamic client for config")
 	}
 
-	kubeclient, err := kubernetes.NewForConfig(externalConfig)
+	kubeClient, err := kubernetes.NewForConfig(externalConfig)
 	if err != nil {
 		klog.Fatalf("create kube clientset failed: %v", err)
 	}
 
-	enableMachineDeployments := false
-	controller, err := newMachineController(dc, kubeclient, enableMachineDeployments)
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(externalConfig)
+	if err != nil {
+		klog.Fatalf("create discovery client failed: %v", err)
+	}
 
+	enableMachineDeployments := false
+	controller, err := newMachineController(dc, kubeClient, discoveryClient, enableMachineDeployments)
 	if err != nil {
 		klog.Fatal(err)
 	}


### PR DESCRIPTION
Decouples the API group from the version and let the latter to be discovered dynamically.

Needs https://github.com/openshift/kubernetes-autoscaler/pull/133