### PR TITLE
UPSTREAM: <carry>: openshift: Implement scale from zero

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_converters_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_converters_test.go
@@ -1,0 +1,399 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterapi
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var ctTimestampNow = metav1.NewTime(time.Now().Truncate(time.Second))
+
+const (
+	ctAPIVersion  = "machine.openshift.io/v1beta1"
+	ctKindMS      = "MachineSet"
+	ctKindMD      = "MachineDeployment"
+	ctKindOR      = "OwnerReference"
+	ctName        = "SomeResource"
+	ctNamespace   = "SomeNamespace"
+	ctUID         = "XXXX"
+	ctLabel1      = "label1"
+	ctLabel1v     = "label1-value"
+	ctTaintKey    = "taintKey"
+	ctTaintValue  = "taintValue"
+	ctTaintEffect = "taintEffect"
+	ctReplicas    = 1
+)
+
+type converterTestConfig struct {
+	name     string
+	expected interface{}
+	observed interface{}
+	compare  func(interface{}, interface{}) bool
+}
+
+func testBoolCompare(expected interface{}, observed interface{}) bool {
+	e := expected.(bool)
+	o := observed.(bool)
+	return (e == o)
+}
+
+func testInt32Compare(expected interface{}, observed interface{}) bool {
+	e := expected.(int32)
+	o := observed.(int32)
+	return (e == o)
+}
+
+func testStringCompare(expected interface{}, observed interface{}) bool {
+	e := expected.(string)
+	o := observed.(string)
+	return (e == o)
+}
+
+func testTimeCompare(expected interface{}, observed interface{}) bool {
+	e := expected.(metav1.Time)
+	o := observed.(metav1.Time)
+	return (e == o)
+}
+
+func testObjectMeta() map[string]interface{} {
+	return map[string]interface{}{
+		"name":      ctName,
+		"namespace": ctNamespace,
+		"uid":       ctUID,
+		"labels": map[string]interface{}{
+			ctLabel1: ctLabel1v,
+		},
+		"annotations": map[string]interface{}{
+			ctLabel1: ctLabel1v,
+		},
+		"ownerReferences": []interface{}{
+			testOwnerReference(),
+		},
+		"deletionTimestamp": ctTimestampNow.ToUnstructured(),
+	}
+}
+
+func testTaint() map[string]interface{} {
+	return map[string]interface{}{
+		"key":       ctTaintKey,
+		"value":     ctTaintValue,
+		"effect":    ctTaintEffect,
+		"timeAdded": ctTimestampNow.ToUnstructured(),
+	}
+}
+
+func testOwnerReference() map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion":         ctAPIVersion,
+		"kind":               ctKindOR,
+		"name":               ctName,
+		"uid":                ctUID,
+		"controller":         true,
+		"blockOwnerDeletion": true,
+	}
+}
+
+func testMachineSetSpec() map[string]interface{} {
+	return map[string]interface{}{
+		"replicas": int64(ctReplicas),
+		"template": map[string]interface{}{
+			"spec": map[string]interface{}{
+				"metadata": testObjectMeta(),
+				"taints": []interface{}{
+					testTaint(),
+				},
+			},
+		},
+	}
+}
+
+func testMachineSet() map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion": ctAPIVersion,
+		"kind":       ctKindMS,
+		"metadata":   testObjectMeta(),
+		"spec":       testMachineSetSpec(),
+	}
+}
+
+func testMachineDeploymentSpec() map[string]interface{} {
+	// for now we can return a machineset spec as it is functionally the same
+	// as a machinedeploymentspec for these tests.
+	return testMachineSetSpec()
+}
+
+func testMachineDeployment() map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion": ctAPIVersion,
+		"kind":       ctKindMD,
+		"metadata":   testObjectMeta(),
+		"spec":       testMachineSetSpec(),
+	}
+}
+
+func doCompares(configs []converterTestConfig, t *testing.T) {
+	for _, config := range configs {
+		t.Run(config.name, func(t *testing.T) {
+			if config.compare == nil {
+				config.compare = testStringCompare
+			}
+			if !config.compare(config.expected, config.observed) {
+				t.Errorf("%s improperly set. Expected %v, Observed %v", config.name, config.expected, config.observed)
+			}
+		})
+	}
+}
+
+func TestConverterNewMachineSetFromUnstructured(t *testing.T) {
+	testobj := unstructured.Unstructured{
+		Object: testMachineSet(),
+	}
+
+	machineSet := newMachineSetFromUnstructured(&testobj)
+
+	testConfigs := []converterTestConfig{
+		{
+			name:     "MachineSet.APIVersion",
+			expected: ctAPIVersion,
+			observed: machineSet.APIVersion,
+		},
+		{
+			name:     "MachineSet.Kind",
+			expected: ctKindMS,
+			observed: machineSet.Kind,
+		},
+		{
+			name:     "MachineSet.Name",
+			expected: ctName,
+			observed: machineSet.Name,
+		},
+		{
+			name:     "machineSet.Namespace",
+			expected: ctNamespace,
+			observed: machineSet.Namespace,
+		},
+		{
+			name:     "MachineSet.UID",
+			expected: ctUID,
+			observed: string(machineSet.UID),
+		},
+		{
+			name:     "MachineSet.Labels",
+			expected: ctLabel1v,
+			observed: machineSet.Labels[ctLabel1],
+		},
+		{
+			name:     "MachineSet.Annotations",
+			expected: ctLabel1v,
+			observed: machineSet.Annotations[ctLabel1],
+		},
+		{
+			name:     "MachineSet.OwnerReferences.APIVersion",
+			expected: ctAPIVersion,
+			observed: machineSet.OwnerReferences[0].APIVersion,
+		},
+		{
+			name:     "MachineSet.OwnerReferences.Kind",
+			expected: ctKindOR,
+			observed: machineSet.OwnerReferences[0].Kind,
+		},
+		{
+			name:     "MachineSet.OwnerReferences.Name",
+			expected: ctName,
+			observed: machineSet.OwnerReferences[0].Name,
+		},
+		{
+			name:     "MachineSet.OwnerReferences.UID",
+			expected: ctUID,
+			observed: string(machineSet.OwnerReferences[0].UID),
+		},
+		{
+			name:     "MachineSet.OwnerReferences.Controller",
+			expected: true,
+			observed: *machineSet.OwnerReferences[0].Controller,
+			compare:  testBoolCompare,
+		},
+		{
+			name:     "MachineSet.OwnerReferences.BlockOwnerDeletion",
+			expected: true,
+			observed: *machineSet.OwnerReferences[0].BlockOwnerDeletion,
+			compare:  testBoolCompare,
+		},
+		{
+			name:     "MachineSet.DeletionTimestamp",
+			expected: ctTimestampNow,
+			observed: *machineSet.DeletionTimestamp,
+			compare:  testTimeCompare,
+		},
+		{
+			name:     "MachineSet.Spec.Replicas",
+			expected: int32(ctReplicas),
+			observed: *machineSet.Spec.Replicas,
+			compare:  testInt32Compare,
+		},
+		{
+			name:     "MachineSet.Spec.Template.Spec.Labels",
+			expected: ctLabel1v,
+			observed: machineSet.Spec.Template.Spec.Labels[ctLabel1],
+		},
+		{
+			name:     "MachineSet.Spec.Template.Spec.Taints.Key",
+			expected: ctTaintKey,
+			observed: machineSet.Spec.Template.Spec.Taints[0].Key,
+		},
+		{
+			name:     "MachineSet.Spec.Template.Spec.Taints.Value",
+			expected: ctTaintValue,
+			observed: machineSet.Spec.Template.Spec.Taints[0].Value,
+		},
+		{
+			name:     "MachineSet.Spec.Template.Spec.Taints.Effect",
+			expected: ctTaintEffect,
+			observed: string(machineSet.Spec.Template.Spec.Taints[0].Effect),
+		},
+		{
+			name:     "MachineSet.Spec.Template.Spec.Taints.TimeAdded",
+			expected: metav1.NewTime(ctTimestampNow.UTC()),
+			observed: *machineSet.Spec.Template.Spec.Taints[0].TimeAdded,
+			compare:  testTimeCompare,
+		},
+	}
+
+	doCompares(testConfigs, t)
+}
+
+func TestConverterNewMachineDeploymentFromUnstructured(t *testing.T) {
+	testobj := unstructured.Unstructured{
+		Object: testMachineDeployment(),
+	}
+
+	machineDeployment := newMachineDeploymentFromUnstructured(&testobj)
+
+	testConfigs := []converterTestConfig{
+		{
+			name:     "MachineDeployment.APIVersion",
+			expected: ctAPIVersion,
+			observed: machineDeployment.APIVersion,
+		},
+		{
+			name:     "MachineDeployment.Kind",
+			expected: ctKindMD,
+			observed: machineDeployment.Kind,
+		},
+		{
+			name:     "MachineDeployment.Name",
+			expected: ctName,
+			observed: machineDeployment.Name,
+		},
+		{
+			name:     "machineDeployment.Namespace",
+			expected: ctNamespace,
+			observed: machineDeployment.Namespace,
+		},
+		{
+			name:     "MachineDeployment.UID",
+			expected: ctUID,
+			observed: string(machineDeployment.UID),
+		},
+		{
+			name:     "MachineDeployment.Labels",
+			expected: ctLabel1v,
+			observed: machineDeployment.Labels[ctLabel1],
+		},
+		{
+			name:     "MachineDeployment.Annotations",
+			expected: ctLabel1v,
+			observed: machineDeployment.Annotations[ctLabel1],
+		},
+		{
+			name:     "MachineDeployment.OwnerReferences.APIVersion",
+			expected: ctAPIVersion,
+			observed: machineDeployment.OwnerReferences[0].APIVersion,
+		},
+		{
+			name:     "MachineDeployment.OwnerReferences.Kind",
+			expected: ctKindOR,
+			observed: machineDeployment.OwnerReferences[0].Kind,
+		},
+		{
+			name:     "MachineDeployment.OwnerReferences.Name",
+			expected: ctName,
+			observed: machineDeployment.OwnerReferences[0].Name,
+		},
+		{
+			name:     "MachineDeployment.OwnerReferences.UID",
+			expected: ctUID,
+			observed: string(machineDeployment.OwnerReferences[0].UID),
+		},
+		{
+			name:     "MachineDeployment.OwnerReferences.Controller",
+			expected: true,
+			observed: *machineDeployment.OwnerReferences[0].Controller,
+			compare:  testBoolCompare,
+		},
+		{
+			name:     "MachineDeployment.OwnerReferences.BlockOwnerDeletion",
+			expected: true,
+			observed: *machineDeployment.OwnerReferences[0].BlockOwnerDeletion,
+			compare:  testBoolCompare,
+		},
+		{
+			name:     "MachineDeployment.DeletionTimestamp",
+			expected: ctTimestampNow,
+			observed: *machineDeployment.DeletionTimestamp,
+			compare:  testTimeCompare,
+		},
+		{
+			name:     "MachineDeployment.Spec.Replicas",
+			expected: int32(ctReplicas),
+			observed: *machineDeployment.Spec.Replicas,
+			compare:  testInt32Compare,
+		},
+		{
+			name:     "MachineDeployment.Spec.Template.Spec.Labels",
+			expected: ctLabel1v,
+			observed: machineDeployment.Spec.Template.Spec.Labels[ctLabel1],
+		},
+		{
+			name:     "MachineDeployment.Spec.Template.Spec.Taints.Key",
+			expected: ctTaintKey,
+			observed: machineDeployment.Spec.Template.Spec.Taints[0].Key,
+		},
+		{
+			name:     "MachineDeployment.Spec.Template.Spec.Taints.Value",
+			expected: ctTaintValue,
+			observed: machineDeployment.Spec.Template.Spec.Taints[0].Value,
+		},
+		{
+			name:     "MachineDeployment.Spec.Template.Spec.Taints.Effect",
+			expected: ctTaintEffect,
+			observed: string(machineDeployment.Spec.Template.Spec.Taints[0].Effect),
+		},
+		{
+			name:     "MachineDeployment.Spec.Template.Spec.Taints.TimeAdded",
+			expected: metav1.NewTime(ctTimestampNow.UTC()),
+			observed: *machineDeployment.Spec.Template.Spec.Taints[0].TimeAdded,
+			compare:  testTimeCompare,
+		},
+	}
+
+	doCompares(testConfigs, t)
+}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machinedeployment.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machinedeployment.go
@@ -22,6 +22,8 @@ import (
 	"path"
 	"time"
 
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/pointer"
@@ -134,4 +136,32 @@ func newMachineDeploymentScalableResource(controller *machineController, machine
 		maxSize:           maxSize,
 		minSize:           minSize,
 	}, nil
+}
+
+func (r machineDeploymentScalableResource) Taints() []apiv1.Taint {
+	return r.machineDeployment.Spec.Template.Spec.Taints
+}
+
+func (r machineDeploymentScalableResource) Labels() map[string]string {
+	return r.machineDeployment.Spec.Template.Spec.Labels
+}
+
+func (r machineDeploymentScalableResource) CanScaleFromZero() bool {
+	return scaleFromZeroEnabled(r.machineDeployment.Annotations)
+}
+
+func (r machineDeploymentScalableResource) InstanceCPUCapacity() (resource.Quantity, error) {
+	return parseCPUCapacity(r.machineDeployment.Annotations)
+}
+
+func (r machineDeploymentScalableResource) InstanceMemoryCapacity() (resource.Quantity, error) {
+	return parseMemoryCapacity(r.machineDeployment.Annotations)
+}
+
+func (r machineDeploymentScalableResource) InstanceGPUCapacity() (resource.Quantity, error) {
+	return parseGPUCapacity(r.machineDeployment.Annotations)
+}
+
+func (r machineDeploymentScalableResource) InstanceMaxPodsCapacity() (resource.Quantity, error) {
+	return parseMaxPodsCapacity(r.machineDeployment.Annotations)
 }

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machineset.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machineset.go
@@ -22,6 +22,8 @@ import (
 	"path"
 	"time"
 
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/pointer"
@@ -119,4 +121,32 @@ func newMachineSetScalableResource(controller *machineController, machineSet *Ma
 		maxSize:    maxSize,
 		minSize:    minSize,
 	}, nil
+}
+
+func (r machineSetScalableResource) Labels() map[string]string {
+	return r.machineSet.Spec.Template.Spec.Labels
+}
+
+func (r machineSetScalableResource) Taints() []apiv1.Taint {
+	return r.machineSet.Spec.Template.Spec.Taints
+}
+
+func (r machineSetScalableResource) CanScaleFromZero() bool {
+	return scaleFromZeroEnabled(r.machineSet.Annotations)
+}
+
+func (r machineSetScalableResource) InstanceCPUCapacity() (resource.Quantity, error) {
+	return parseCPUCapacity(r.machineSet.Annotations)
+}
+
+func (r machineSetScalableResource) InstanceMemoryCapacity() (resource.Quantity, error) {
+	return parseMemoryCapacity(r.machineSet.Annotations)
+}
+
+func (r machineSetScalableResource) InstanceGPUCapacity() (resource.Quantity, error) {
+	return parseGPUCapacity(r.machineSet.Annotations)
+}
+
+func (r machineSetScalableResource) InstanceMaxPodsCapacity() (resource.Quantity, error) {
+	return parseMaxPodsCapacity(r.machineSet.Annotations)
 }

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -168,10 +168,6 @@ func TestNodeGroupNewNodeGroupConstructor(t *testing.T) {
 			t.Errorf("expected %q, got %q", expectedDebug, ng.Debug())
 		}
 
-		if _, err := ng.TemplateNodeInfo(); err != cloudprovider.ErrNotImplemented {
-			t.Error("expected error")
-		}
-
 		if exists := ng.Exist(); !exists {
 			t.Errorf("expected %t, got %t", true, exists)
 		}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_scalableresource.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_scalableresource.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package clusterapi
 
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
 // scalableResource is a resource that can be scaled up and down by
 // adjusting its replica count field.
 type scalableResource interface {
@@ -46,4 +51,12 @@ type scalableResource interface {
 
 	// MarkMachineForDeletion marks machine for deletion
 	MarkMachineForDeletion(machine *Machine) error
+
+	Labels() map[string]string
+	Taints() []apiv1.Taint
+	CanScaleFromZero() bool
+	InstanceCPUCapacity() (resource.Quantity, error)
+	InstanceMemoryCapacity() (resource.Quantity, error)
+	InstanceGPUCapacity() (resource.Quantity, error)
+	InstanceMaxPodsCapacity() (resource.Quantity, error)
 }

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
@@ -17,16 +17,23 @@ limitations under the License.
 package clusterapi
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
 	nodeGroupMinSizeAnnotationKey = "machine.openshift.io/cluster-api-autoscaler-node-group-min-size"
 	nodeGroupMaxSizeAnnotationKey = "machine.openshift.io/cluster-api-autoscaler-node-group-max-size"
+
+	cpuKey     = "machine.openshift.io/vCPU"
+	memoryKey  = "machine.openshift.io/memoryMb"
+	gpuKey     = "machine.openshift.io/GPU"
+	maxPodsKey = "machine.openshift.io/maxPods"
 )
 
 var (
@@ -47,6 +54,8 @@ var (
 	// errInvalidMaxAnnotationValue is the error returned when a
 	// machine set has a non-integral max annotation value.
 	errInvalidMaxAnnotation = errors.New("invalid max annotation")
+
+	zeroQuantity = resource.MustParse("0")
 )
 
 type normalizedProviderID string
@@ -152,4 +161,48 @@ func machineSetIsOwnedByMachineDeployment(machineSet *MachineSet, machineDeploym
 func normalizedProviderString(s string) normalizedProviderID {
 	split := strings.Split(s, "/")
 	return normalizedProviderID(split[len(split)-1])
+}
+
+func scaleFromZeroEnabled(annotations map[string]string) bool {
+	cpu := annotations[cpuKey]
+	mem := annotations[memoryKey]
+
+	if cpu != "" && mem != "" {
+		return true
+	}
+	return false
+}
+
+func parseKey(annotations map[string]string, key string) (resource.Quantity, error) {
+	if val, exists := annotations[key]; exists && val != "" {
+		return resource.ParseQuantity(val)
+	}
+	return zeroQuantity.DeepCopy(), nil
+}
+
+func parseCPUCapacity(annotations map[string]string) (resource.Quantity, error) {
+	return parseKey(annotations, cpuKey)
+}
+
+func parseMemoryCapacity(annotations map[string]string) (resource.Quantity, error) {
+	// the value for the memoryKey is expected to have the unit type included,
+	// eg "1024Mi". if only a number is present, we add the suffix "Mi".
+	val, exists := annotations[memoryKey]
+	if exists && val != "" {
+		// TODO remove this check once we ensured that the providers are using the correct values
+		if _, err := strconv.Atoi(val); err == nil {
+			// value is a number, we will append "Mi" as the unit type
+			val = fmt.Sprintf("%sMi", val)
+		}
+		return resource.ParseQuantity(val)
+	}
+	return zeroQuantity.DeepCopy(), nil
+}
+
+func parseGPUCapacity(annotations map[string]string) (resource.Quantity, error) {
+	return parseKey(annotations, gpuKey)
+}
+
+func parseMaxPodsCapacity(annotations map[string]string) (resource.Quantity, error) {
+	return parseKey(annotations, maxPodsKey)
 }

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -396,6 +397,220 @@ func TestUtilNormalizedProviderID(t *testing.T) {
 			actualID := normalizedProviderString(tc.providerID)
 			if actualID != tc.expectedID {
 				t.Errorf("expected %v, got %v", tc.expectedID, actualID)
+			}
+		})
+	}
+}
+
+func TestScaleFromZeroEnabled(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		enabled     bool
+		annotations map[string]string
+	}{{
+		description: "nil annotations",
+		enabled:     false,
+	}, {
+		description: "empty annotations",
+		annotations: map[string]string{},
+		enabled:     false,
+	}, {
+		description: "non-matching annotation",
+		annotations: map[string]string{"foo": "bar"},
+		enabled:     false,
+	}, {
+		description: "matching key, incomplete annotations",
+		annotations: map[string]string{
+			"foo":  "bar",
+			cpuKey: "1",
+			gpuKey: "2",
+		},
+		enabled: false,
+	}, {
+		description: "matching key, complete annotations",
+		annotations: map[string]string{
+			"foo":     "bar",
+			cpuKey:    "1",
+			memoryKey: "2",
+		},
+		enabled: true,
+	}} {
+		t.Run(tc.description, func(t *testing.T) {
+			got := scaleFromZeroEnabled(tc.annotations)
+			if tc.enabled != got {
+				t.Errorf("expected %t, got %t", tc.enabled, got)
+			}
+		})
+	}
+}
+
+func TestParseCPUCapacity(t *testing.T) {
+	for _, tc := range []struct {
+		description      string
+		annotations      map[string]string
+		expectedQuantity resource.Quantity
+		expectedError    bool
+	}{{
+		description:      "nil annotations",
+		expectedQuantity: zeroQuantity.DeepCopy(),
+		expectedError:    false,
+	}, {
+		description:      "empty annotations",
+		annotations:      map[string]string{},
+		expectedQuantity: zeroQuantity.DeepCopy(),
+		expectedError:    false,
+	}, {
+		description:      "bad quantity",
+		annotations:      map[string]string{cpuKey: "not-a-quantity"},
+		expectedQuantity: zeroQuantity.DeepCopy(),
+		expectedError:    true,
+	}, {
+		description:      "valid quantity with units",
+		annotations:      map[string]string{cpuKey: "123m"},
+		expectedError:    false,
+		expectedQuantity: resource.MustParse("123m"),
+	}, {
+		description:      "valid quantity without units",
+		annotations:      map[string]string{cpuKey: "1"},
+		expectedError:    false,
+		expectedQuantity: resource.MustParse("1"),
+	}, {
+		description:      "valid fractional quantity without units",
+		annotations:      map[string]string{cpuKey: "0.1"},
+		expectedError:    false,
+		expectedQuantity: resource.MustParse("0.1"),
+	}} {
+		t.Run(tc.description, func(t *testing.T) {
+			got, err := parseCPUCapacity(tc.annotations)
+			if tc.expectedError && err == nil {
+				t.Fatal("expected an error")
+			}
+			if tc.expectedQuantity.Cmp(got) != 0 {
+				t.Errorf("expected %v, got %v", tc.expectedQuantity.String(), got.String())
+			}
+		})
+	}
+}
+
+func TestParseMemoryCapacity(t *testing.T) {
+	for _, tc := range []struct {
+		description      string
+		annotations      map[string]string
+		expectedQuantity resource.Quantity
+		expectedError    bool
+	}{{
+		description:      "nil annotations",
+		expectedQuantity: zeroQuantity.DeepCopy(),
+		expectedError:    false,
+	}, {
+		description:      "empty annotations",
+		annotations:      map[string]string{},
+		expectedQuantity: zeroQuantity.DeepCopy(),
+		expectedError:    false,
+	}, {
+		description:      "bad quantity",
+		annotations:      map[string]string{memoryKey: "not-a-quantity"},
+		expectedQuantity: zeroQuantity.DeepCopy(),
+		expectedError:    true,
+	}, {
+		description:      "valid quantity without unit type",
+		annotations:      map[string]string{memoryKey: "456"},
+		expectedError:    false,
+		expectedQuantity: resource.MustParse("456Mi"),
+	}, {
+		description:      "valid quantity with unit type (Mi)",
+		annotations:      map[string]string{memoryKey: "456Mi"},
+		expectedError:    false,
+		expectedQuantity: resource.MustParse("456Mi"),
+	}, {
+		description:      "valid quantity with unit type (Gi)",
+		annotations:      map[string]string{memoryKey: "8Gi"},
+		expectedError:    false,
+		expectedQuantity: resource.MustParse("8Gi"),
+	}} {
+		t.Run(tc.description, func(t *testing.T) {
+			got, err := parseMemoryCapacity(tc.annotations)
+			if tc.expectedError && err == nil {
+				t.Fatal("expected an error")
+			}
+			if tc.expectedQuantity.Cmp(got) != 0 {
+				t.Errorf("expected %v, got %v", tc.expectedQuantity.String(), got.String())
+			}
+		})
+	}
+}
+
+func TestParseGPUCapacity(t *testing.T) {
+	for _, tc := range []struct {
+		description      string
+		annotations      map[string]string
+		expectedQuantity resource.Quantity
+		expectedError    bool
+	}{{
+		description:      "nil annotations",
+		expectedQuantity: zeroQuantity.DeepCopy(),
+		expectedError:    false,
+	}, {
+		description:      "empty annotations",
+		annotations:      map[string]string{},
+		expectedQuantity: zeroQuantity.DeepCopy(),
+		expectedError:    false,
+	}, {
+		description:      "bad quantity",
+		annotations:      map[string]string{gpuKey: "not-a-quantity"},
+		expectedQuantity: zeroQuantity.DeepCopy(),
+		expectedError:    true,
+	}, {
+		description:      "valid quantity",
+		annotations:      map[string]string{gpuKey: "13"},
+		expectedError:    false,
+		expectedQuantity: resource.MustParse("13"),
+	}} {
+		t.Run(tc.description, func(t *testing.T) {
+			got, err := parseGPUCapacity(tc.annotations)
+			if tc.expectedError && err == nil {
+				t.Fatal("expected an error")
+			}
+			if tc.expectedQuantity.Cmp(got) != 0 {
+				t.Errorf("expected %v, got %v", tc.expectedQuantity.String(), got.String())
+			}
+		})
+	}
+}
+
+func TestParseMaxPodsCapacity(t *testing.T) {
+	for _, tc := range []struct {
+		description      string
+		annotations      map[string]string
+		expectedQuantity resource.Quantity
+		expectedError    bool
+	}{{
+		description:      "nil annotations",
+		expectedQuantity: zeroQuantity.DeepCopy(),
+		expectedError:    false,
+	}, {
+		description:      "empty annotations",
+		annotations:      map[string]string{},
+		expectedQuantity: zeroQuantity.DeepCopy(),
+		expectedError:    false,
+	}, {
+		description:      "bad quantity",
+		annotations:      map[string]string{maxPodsKey: "not-a-quantity"},
+		expectedQuantity: zeroQuantity.DeepCopy(),
+		expectedError:    true,
+	}, {
+		description:      "valid quantity",
+		annotations:      map[string]string{maxPodsKey: "13"},
+		expectedError:    false,
+		expectedQuantity: resource.MustParse("13"),
+	}} {
+		t.Run(tc.description, func(t *testing.T) {
+			got, err := parseMaxPodsCapacity(tc.annotations)
+			if tc.expectedError && err == nil {
+				t.Fatal("expected an error")
+			}
+			if tc.expectedQuantity.Cmp(got) != 0 {
+				t.Errorf("expected %v, got %v", tc.expectedQuantity.String(), got.String())
 			}
 		})
 	}


### PR DESCRIPTION
This allows a Machine{Set,Deployment} to scale up/down from 0,
providing the following annotations are set:

```yaml
apiVersion: v1
items:
- apiVersion: machine.openshift.io/v1beta1
  kind: MachineSet
  metadata:
    annotations:
      machine.openshift.io/cluster-api-autoscaler-node-group-min-size: "0"
      machine.openshift.io/cluster-api-autoscaler-node-group-max-size: "6"
      machine.openshift.io/vCPU: "2"
      machine.openshift.io/memoryMb: 8G
      machine.openshift.io/GPU: "1"
      machine.openshift.io/maxPods: "100"
```

please note that `machine.openshift.io/maxPods` is not required for scale to/from zero operations.

this PR is a continuation of the work started in #110 

Counterpart PRs:
openshift/cluster-api-provider-aws#301
openshift/cluster-api-provider-azure#112
Design details:
openshift/enhancements#186