### PR TITLE
BUG 1820410: UPSTREAM: 3034: openshift: Improve delete node mechanisms

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machinedeployment.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machinedeployment.go
@@ -101,6 +101,10 @@ func (r machineDeploymentScalableResource) SetSize(nreplicas int32) error {
 	return updateErr
 }
 
+func (r machineDeploymentScalableResource) UnmarkMachineForDeletion(machine *Machine) error {
+	return unmarkMachineForDeletion(r.controller, machine)
+}
+
 func (r machineDeploymentScalableResource) MarkMachineForDeletion(machine *Machine) error {
 	u, err := r.controller.dynamicclient.Resource(*r.controller.machineResource).Namespace(machine.Namespace).Get(context.TODO(), machine.Name, metav1.GetOptions{})
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machineset.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machineset.go
@@ -109,6 +109,10 @@ func (r machineSetScalableResource) MarkMachineForDeletion(machine *Machine) err
 	return updateErr
 }
 
+func (r machineSetScalableResource) UnmarkMachineForDeletion(machine *Machine) error {
+	return unmarkMachineForDeletion(r.controller, machine)
+}
+
 func newMachineSetScalableResource(controller *machineController, machineSet *MachineSet) (*machineSetScalableResource, error) {
 	minSize, maxSize, err := parseScalingBounds(machineSet.Annotations)
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -150,6 +150,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 		}
 
 		if err := ng.scalableResource.SetSize(replicas - 1); err != nil {
+			nodeGroup.scalableResource.UnmarkMachineForDeletion(machine)
 			return err
 		}
 


### PR DESCRIPTION
This change adds two different checks for improving the behavior of node
deletion. The first is to check against the node group minimum size
instead of zero for determining early scale down failure events. The
second is to help prevent race conditions in the annotation labeling for
machines marked for deletion.