### PR TITLE
BUG 1820654: UPSTREAM: <carry>: openshift: Fallback to status if replicas nil in spec

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_converters.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_converters.go
@@ -82,9 +82,12 @@ func newMachineDeploymentFromUnstructured(u *unstructured.Unstructured) *Machine
 		}
 	}
 
-	replicas, found, err := unstructured.NestedInt64(u.Object, "spec", "replicas")
-	if err == nil && found {
+	if replicas, found, err := unstructured.NestedInt64(u.Object, "spec", "replicas"); err == nil && found {
 		machineDeployment.Spec.Replicas = pointer.Int32Ptr(int32(replicas))
+	}
+
+	if replicas, found, err := unstructured.NestedInt64(u.Object, "status", "replicas"); err == nil && found {
+		machineDeployment.Status.Replicas = int32(replicas)
 	}
 
 	return &machineDeployment
@@ -123,9 +126,12 @@ func newMachineSetFromUnstructured(u *unstructured.Unstructured) *MachineSet {
 		}
 	}
 
-	replicas, found, err := unstructured.NestedInt64(u.Object, "spec", "replicas")
-	if err == nil && found {
+	if replicas, found, err := unstructured.NestedInt64(u.Object, "spec", "replicas"); err == nil && found {
 		machineSet.Spec.Replicas = pointer.Int32Ptr(int32(replicas))
+	}
+
+	if replicas, found, err := unstructured.NestedInt64(u.Object, "status", "replicas"); err == nil && found {
+		machineSet.Status.Replicas = int32(replicas)
 	}
 
 	return &machineSet
@@ -192,6 +198,7 @@ func newUnstructuredFromMachineSet(m *MachineSet) *unstructured.Unstructured {
 	if m.Spec.Replicas != nil {
 		unstructured.SetNestedField(u.Object, int64(*m.Spec.Replicas), "spec", "replicas")
 	}
+	unstructured.SetNestedField(u.Object, int64(m.Status.Replicas), "status", "replicas")
 
 	return &u
 }
@@ -212,6 +219,7 @@ func newUnstructuredFromMachineDeployment(m *MachineDeployment) *unstructured.Un
 	if m.Spec.Replicas != nil {
 		unstructured.SetNestedField(u.Object, int64(*m.Spec.Replicas), "spec", "replicas")
 	}
+	unstructured.SetNestedField(u.Object, int64(m.Status.Replicas), "status", "replicas")
 
 	return &u
 }

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_converters_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_converters_test.go
@@ -125,12 +125,19 @@ func testMachineSetSpec() map[string]interface{} {
 	}
 }
 
+func testMachineSetStatus() map[string]interface{} {
+	return map[string]interface{}{
+		"replicas": int64(ctReplicas),
+	}
+}
+
 func testMachineSet() map[string]interface{} {
 	return map[string]interface{}{
 		"apiVersion": ctAPIVersion,
 		"kind":       ctKindMS,
 		"metadata":   testObjectMeta(),
 		"spec":       testMachineSetSpec(),
+		"status":     testMachineSetStatus(),
 	}
 }
 
@@ -140,12 +147,19 @@ func testMachineDeploymentSpec() map[string]interface{} {
 	return testMachineSetSpec()
 }
 
+func testMachineDeploymentStatus() map[string]interface{} {
+	// for now we can return a machineset spec as it is functionally the same
+	// as a machinedeploymentspec for these tests.
+	return testMachineSetStatus()
+}
+
 func testMachineDeployment() map[string]interface{} {
 	return map[string]interface{}{
 		"apiVersion": ctAPIVersion,
 		"kind":       ctKindMD,
 		"metadata":   testObjectMeta(),
-		"spec":       testMachineSetSpec(),
+		"spec":       testMachineDeploymentSpec(),
+		"status":     testMachineDeploymentStatus(),
 	}
 }
 
@@ -275,6 +289,12 @@ func TestConverterNewMachineSetFromUnstructured(t *testing.T) {
 			observed: *machineSet.Spec.Template.Spec.Taints[0].TimeAdded,
 			compare:  testTimeCompare,
 		},
+		{
+			name:     "MachineSet.Status.Replicas",
+			expected: int32(ctReplicas),
+			observed: machineSet.Status.Replicas,
+			compare:  testInt32Compare,
+		},
 	}
 
 	doCompares(testConfigs, t)
@@ -392,6 +412,12 @@ func TestConverterNewMachineDeploymentFromUnstructured(t *testing.T) {
 			expected: metav1.NewTime(ctTimestampNow.UTC()),
 			observed: *machineDeployment.Spec.Template.Spec.Taints[0].TimeAdded,
 			compare:  testTimeCompare,
+		},
+		{
+			name:     "MachineDeployment.Status.Replicas",
+			expected: int32(ctReplicas),
+			observed: machineDeployment.Status.Replicas,
+			compare:  testInt32Compare,
 		},
 	}
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machineset.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machineset.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog"
 	"k8s.io/utils/pointer"
 )
 
@@ -63,7 +64,13 @@ func (r machineSetScalableResource) Nodes() ([]string, error) {
 }
 
 func (r machineSetScalableResource) Replicas() int32 {
-	return pointer.Int32PtrDerefOr(r.machineSet.Spec.Replicas, 0)
+	if r.machineSet.Spec.Replicas == nil {
+		klog.Warningf("MachineSet %q has nil spec.replicas. This is unsupported behaviour. Falling back to status.replicas.", r.machineSet.Name)
+	}
+
+	// If no value for replicas on the MachineSet spec, fallback to the status
+	// TODO: Remove this fallback once defaulting is implemented for MachineSet Replicas
+	return pointer.Int32PtrDerefOr(r.machineSet.Spec.Replicas, r.machineSet.Status.Replicas)
 }
 
 func (r machineSetScalableResource) SetSize(nreplicas int32) error {

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -313,10 +313,11 @@ func TestNodeGroupIncreaseSizeErrors(t *testing.T) {
 
 func TestNodeGroupIncreaseSize(t *testing.T) {
 	type testCase struct {
-		description string
-		delta       int
-		initial     int32
-		expected    int32
+		description   string
+		delta         int
+		initialSpec   *int32
+		initialStatus int32
+		expected      int32
 	}
 
 	test := func(t *testing.T, tc *testCase, testConfig *testConfig) {
@@ -338,8 +339,16 @@ func TestNodeGroupIncreaseSize(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		if currReplicas != int(tc.initial) {
-			t.Errorf("initially expected %v, got %v", tc.initial, currReplicas)
+		// If initialSpec is nil, fallback to replica count from status
+		// TODO: Remove this fallback once defaulting is implemented for MachineSet Replicas
+		if tc.initialSpec != nil {
+			if currReplicas != int(pointer.Int32PtrDerefOr(tc.initialSpec, -1)) {
+				t.Errorf("initially expected %v, got %v", tc.initialSpec, currReplicas)
+			}
+		} else {
+			if currReplicas != int(tc.initialStatus) {
+				t.Errorf("initially expected %v, got %v", tc.initialStatus, currReplicas)
+			}
 		}
 
 		if err := ng.IncreaseSize(tc.delta); err != nil {
@@ -378,21 +387,43 @@ func TestNodeGroupIncreaseSize(t *testing.T) {
 	t.Run("MachineSet", func(t *testing.T) {
 		tc := testCase{
 			description: "increase by 1",
-			initial:     3,
+			initialSpec: pointer.Int32Ptr(3),
 			expected:    4,
 			delta:       1,
 		}
-		test(t, &tc, createMachineSetTestConfig(testNamespace, int(tc.initial), annotations))
+		test(t, &tc, createMachineSetTestConfig(testNamespace, int(*tc.initialSpec), annotations))
 	})
 
 	t.Run("MachineDeployment", func(t *testing.T) {
 		tc := testCase{
 			description: "increase by 1",
-			initial:     3,
+			initialSpec: pointer.Int32Ptr(3),
 			expected:    4,
 			delta:       1,
 		}
-		test(t, &tc, createMachineDeploymentTestConfig(testNamespace, int(tc.initial), annotations))
+		test(t, &tc, createMachineDeploymentTestConfig(testNamespace, int(*tc.initialSpec), annotations))
+	})
+
+	t.Run("MachineSet with nil Spec.Replicas", func(t *testing.T) {
+		tc := testCase{
+			description:   "increase by 3",
+			initialSpec:   nil,
+			initialStatus: 2,
+			expected:      5,
+			delta:         3,
+		}
+		test(t, &tc, createMachineSetTestConfig(testNamespace, int(tc.initialStatus), annotations))
+	})
+
+	t.Run("MachineDeployment with nil Spec.Replicas", func(t *testing.T) {
+		tc := testCase{
+			description:   "increase by 3",
+			initialSpec:   nil,
+			initialStatus: 2,
+			expected:      5,
+			delta:         3,
+		}
+		test(t, &tc, createMachineDeploymentTestConfig(testNamespace, int(tc.initialStatus), annotations))
 	})
 }
 
@@ -400,7 +431,8 @@ func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 	type testCase struct {
 		description         string
 		delta               int
-		initial             int32
+		initialSpec         *int32
+		initialStatus       int32
 		targetSizeIncrement int32
 		expected            int32
 		expectedError       bool
@@ -446,8 +478,17 @@ func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if currReplicas != int(tc.initial)+int(tc.targetSizeIncrement) {
-			t.Errorf("initially expected %v, got %v", tc.initial, currReplicas)
+
+		// If initialSpec is nil, fallback to replica count from status
+		// TODO: Remove this fallback once defaulting is implemented for MachineSet Replicas
+		if tc.initialSpec != nil {
+			if currReplicas != int(*tc.initialSpec)+int(tc.targetSizeIncrement) {
+				t.Errorf("initially expected %v, got %v", tc.initialSpec, currReplicas)
+			}
+		} else {
+			if currReplicas != int(tc.initialStatus)+int(tc.targetSizeIncrement) {
+				t.Errorf("initially expected %v, got %v", tc.initialStatus, currReplicas)
+			}
 		}
 
 		if err := ng.DecreaseTargetSize(tc.delta); (err != nil) != tc.expectedError {
@@ -486,36 +527,48 @@ func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 	t.Run("MachineSet", func(t *testing.T) {
 		tc := testCase{
 			description:         "Same number of existing instances and node group target size should error",
-			initial:             3,
+			initialSpec:         pointer.Int32Ptr(3),
 			targetSizeIncrement: 0,
 			expected:            3,
 			delta:               -1,
 			expectedError:       true,
 		}
-		test(t, &tc, createMachineSetTestConfig(testNamespace, int(tc.initial), annotations))
+		test(t, &tc, createMachineSetTestConfig(testNamespace, int(*tc.initialSpec), annotations))
 	})
 
 	t.Run("MachineSet", func(t *testing.T) {
 		tc := testCase{
 			description:         "A node group with targe size 4 but only 3 existing instances should decrease by 1",
-			initial:             3,
+			initialSpec:         pointer.Int32Ptr(3),
 			targetSizeIncrement: 1,
 			expected:            3,
 			delta:               -1,
 		}
-		test(t, &tc, createMachineSetTestConfig(testNamespace, int(tc.initial), annotations))
+		test(t, &tc, createMachineSetTestConfig(testNamespace, int(*tc.initialSpec), annotations))
 	})
 
 	t.Run("MachineDeployment", func(t *testing.T) {
 		tc := testCase{
 			description:         "Same number of existing instances and node group target size should error",
-			initial:             3,
+			initialSpec:         pointer.Int32Ptr(3),
 			targetSizeIncrement: 0,
 			expected:            3,
 			delta:               -1,
 			expectedError:       true,
 		}
-		test(t, &tc, createMachineDeploymentTestConfig(testNamespace, int(tc.initial), annotations))
+		test(t, &tc, createMachineDeploymentTestConfig(testNamespace, int(*tc.initialSpec), annotations))
+	})
+
+	t.Run("MachineSet with nil Spec.Replicas", func(t *testing.T) {
+		tc := testCase{
+			description:         "A node group with targe size 6 but only 4 existing instances should decrease by 2",
+			initialSpec:         nil,
+			initialStatus:       4,
+			targetSizeIncrement: 2,
+			expected:            4,
+			delta:               -2,
+		}
+		test(t, &tc, createMachineSetTestConfig(testNamespace, int(tc.initialStatus), annotations))
 	})
 }
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/machinedeployment_types.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/machinedeployment_types.go
@@ -36,7 +36,12 @@ type MachineDeploymentSpec struct {
 }
 
 // MachineDeploymentStatus is the internal autoscaler Schema for MachineDeploymentStatus
-type MachineDeploymentStatus struct{}
+type MachineDeploymentStatus struct {
+	// Total number of non-terminated machines targeted by this deployment
+	// (their labels match the selector).
+	// +optional
+	Replicas int32 `json:"replicas,omitempty"`
+}
 
 // MachineDeployment is the internal autoscaler Schema for MachineDeployment
 type MachineDeployment struct {

--- a/cluster-autoscaler/cloudprovider/clusterapi/machineset_types.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/machineset_types.go
@@ -68,7 +68,10 @@ type MachineTemplateSpec struct {
 }
 
 // MachineSetStatus is the internal autoscaler Schema for MachineSetStatus
-type MachineSetStatus struct{}
+type MachineSetStatus struct {
+	// Replicas is the most recently observed number of replicas.
+	Replicas int32 `json:"replicas"`
+}
 
 // MachineSetList is the internal autoscaler Schema for MachineSetList
 type MachineSetList struct {


### PR DESCRIPTION
Since we don't have defaulting for MachineSets, we can get into a scenario where the replicas field is nil. Currently the behaviour for dereferencing the replicas returns 0 if the replicas field is nil. This prevents scaling operations at present.

This PR adds a fallback mechanism which uses the `status.replicas` field instead if the `spec.replicas` field is not present. This should allow the autoscaler to continue working