### PR TITLE
BUG 1824215: Raise maximum memory capacity difference

### DIFF
--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
@@ -33,7 +33,7 @@ const (
 	MaxFreeDifferenceRatio = 0.05
 	// MaxMemoryDifferenceInKiloBytes describes how much memory
 	// capacity can differ but still be considered equal.
-	MaxMemoryDifferenceInKiloBytes = 128000
+	MaxMemoryDifferenceInKiloBytes = 256000
 )
 
 // BasicIgnoredLabels define a set of basic labels that should be ignored when comparing the similarity


### PR DESCRIPTION
Allow instances to have up to a 256KB delta in actual memory capacity

This commit was introduced into master during the 4.4 release cycle as part of #121 