### PR TITLE
BUG: 1828288: Deprecate machine.openshift.io/memoryMb annotation in favour of machine.openshift.io/memory

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
@@ -527,6 +527,16 @@ func TestParseMemoryCapacity(t *testing.T) {
 		annotations:      map[string]string{memoryKey: "8Gi"},
 		expectedError:    false,
 		expectedQuantity: resource.MustParse("8Gi"),
+	}, {
+		description:      "using deprecated annotation with unit type (Gi)",
+		annotations:      map[string]string{memoryKeyDeprecated: "8Gi"},
+		expectedError:    false,
+		expectedQuantity: resource.MustParse("8Gi"),
+	}, {
+		description:      "using deprecated annotation without unit type",
+		annotations:      map[string]string{memoryKeyDeprecated: "456"},
+		expectedError:    false,
+		expectedQuantity: resource.MustParse("456Mi"),
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
 			got, err := parseMemoryCapacity(tc.annotations)


### PR DESCRIPTION
Cluster autoscaler and aws/gcp/azure controllers should drop the "machine.openshift.io/memoryMb" deprecated annotation and use only "machine.openshift.io/memory".

This way controllers are responsible to set the unit format according to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory while the autoscaler should be able to read it appropiately.
This is more robust and practical than the current approach and assumptions.
https://bugzilla.redhat.com/show_bug.cgi?id=1828288