### PR TITLE
Bug 1828731: UPSTREAM: <carry>: Convert the mem value consistently with other providers

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
 )
 
 const (
@@ -513,20 +514,20 @@ func TestParseMemoryCapacity(t *testing.T) {
 		expectedQuantity: zeroQuantity.DeepCopy(),
 		expectedError:    true,
 	}, {
-		description:      "valid quantity without unit type",
+		description:      "valid quantity",
 		annotations:      map[string]string{memoryKey: "456"},
 		expectedError:    false,
-		expectedQuantity: resource.MustParse("456Mi"),
+		expectedQuantity: *resource.NewQuantity(456*units.MiB, resource.DecimalSI),
 	}, {
-		description:      "valid quantity with unit type (Mi)",
+		description:      "quantity with unit type (Mi)",
 		annotations:      map[string]string{memoryKey: "456Mi"},
-		expectedError:    false,
-		expectedQuantity: resource.MustParse("456Mi"),
+		expectedError:    true,
+		expectedQuantity: zeroQuantity.DeepCopy(),
 	}, {
-		description:      "valid quantity with unit type (Gi)",
+		description:      "quantity with unit type (Gi)",
 		annotations:      map[string]string{memoryKey: "8Gi"},
-		expectedError:    false,
-		expectedQuantity: resource.MustParse("8Gi"),
+		expectedError:    true,
+		expectedQuantity: zeroQuantity.DeepCopy(),
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
 			got, err := parseMemoryCapacity(tc.annotations)


### PR DESCRIPTION
For autoscaling from zero, the autoscaler should convert the mem value received in the appropriate annotation to bytes using powers of two consistently with other providers and fail if the format received is not expected. This gives robust behaviour consistent with cloud providers APIs and providers implementations.

https://cloud.google.com/compute/all-pricing
https://www.iec.ch/si/binary.htm
https://github.com/openshift/kubernetes-autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/aws_manager.go#L366