### PR TITLE
Skip DeleteNodesTwice test while waiting for fix

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -867,6 +867,9 @@ func TestNodeGroupMachineSetDeleteNodesWithMismatchedNodes(t *testing.T) {
 }
 
 func TestNodeGroupDeleteNodesTwice(t *testing.T) {
+	// Remove this skip once #151 is merged, which is currently blocked on #3124 upstream
+	t.Skip("Test is currently broken, waiting on #151 to be merged")
+
 	addDeletionTimestamp := func(t *testing.T, controller *machineController, machine *Machine) error {
 		// Simulate delete that would have happened if the
 		// Machine API controllers were running Don't actually


### PR DESCRIPTION
Currently this test is broken, it will be fixed by #151 once that is merged, but we want to merge the upstream 3124 PR first.

I've included 3124 in the commit message here as this can be dropped once that PR is merged. I think that is appropriate usage of the commit format but correct me if I'm wrong.