### PR TITLE
UPSTREAM: <carry>: remove redundant error checks in mark/unmark deletion functions

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machinedeployment.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machinedeployment.go
@@ -122,12 +122,8 @@ func (r machineDeploymentScalableResource) UnmarkMachineForDeletion(machine *Mac
 
 func (r machineDeploymentScalableResource) MarkMachineForDeletion(machine *Machine) error {
 	u, err := r.controller.dynamicclient.Resource(*r.controller.machineResource).Namespace(machine.Namespace).Get(context.TODO(), machine.Name, metav1.GetOptions{})
-
 	if err != nil {
 		return err
-	}
-	if u == nil {
-		return fmt.Errorf("unknown machine %s", machine.Name)
 	}
 
 	u = u.DeepCopy()

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machineset.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machineset.go
@@ -104,12 +104,8 @@ func (r machineSetScalableResource) SetSize(nreplicas int32) error {
 
 func (r machineSetScalableResource) MarkMachineForDeletion(machine *Machine) error {
 	u, err := r.controller.dynamicclient.Resource(*r.controller.machineResource).Namespace(machine.Namespace).Get(context.TODO(), machine.Name, metav1.GetOptions{})
-
 	if err != nil {
 		return err
-	}
-	if u == nil {
-		return fmt.Errorf("unknown machine %s", machine.Name)
 	}
 
 	u = u.DeepCopy()

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_scalableresource.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_scalableresource.go
@@ -18,7 +18,6 @@ package clusterapi
 
 import (
 	"context"
-	"fmt"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -70,12 +69,8 @@ type scalableResource interface {
 
 func unmarkMachineForDeletion(controller *machineController, machine *Machine) error {
 	u, err := controller.dynamicclient.Resource(*controller.machineResource).Namespace(machine.Namespace).Get(context.TODO(), machine.Name, metav1.GetOptions{})
-
 	if err != nil {
 		return err
-	}
-	if u == nil {
-		return fmt.Errorf("unknown machine %s", machine.Name)
 	}
 
 	annotations := u.GetAnnotations()


### PR DESCRIPTION
This change removes a few nil checks against resources returned in the
Mark and Unmark deletion functions of the cluster-autoscaler CAPI
provider. These checks look to see if the returned value for a resource
are nil, but the function will not return nil if it returns an
error[0]. We only need to check the error return as discussed here[1].

[0]
https://github.com/kubernetes/client-go/blob/master/dynamic/simple.go#L234
[1]
https://github.com/openshift/kubernetes-autoscaler/pull/141/files#r414480960