### PR TITLE
Bug 1852061: Fallback to Status Replicas if Replicas nil when listing NodeGroups

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -507,7 +507,7 @@ func (c *machineController) machineSetNodeGroups() ([]*nodegroup, error) {
 		if ng.MaxSize()-ng.MinSize() > 0 {
 			if ng.scalableResource.CanScaleFromZero() {
 				nodegroups = append(nodegroups, ng)
-			} else if pointer.Int32PtrDerefOr(machineSet.Spec.Replicas, 0) > 0 {
+			} else if pointer.Int32PtrDerefOr(machineSet.Spec.Replicas, machineSet.Status.Replicas) > 0 {
 				nodegroups = append(nodegroups, ng)
 			}
 		}


### PR DESCRIPTION
If a nodegroup cannot scale from zero, and the replicas count is `nil`, then the nodegroup will be ignored by the autoscaler and won't be scaled. We implemented #143 to prevent allow the autoscaler to continue operating when replicas is `nil`, but it only works for nodegroups that can scale from zero presently.