### PR TITLE
Bug 1835160: Fallback to Status Replicas if Replicas nil when listing NodeGroups

### DIFF
--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller.go
@@ -362,7 +362,7 @@ func (c *machineController) machineSetNodeGroups() ([]*nodegroup, error) {
 		if err != nil {
 			return err
 		}
-		if ng.MaxSize()-ng.MinSize() > 0 && pointer.Int32PtrDerefOr(machineSet.Spec.Replicas, 0) > 0 {
+		if ng.MaxSize()-ng.MinSize() > 0 && pointer.Int32PtrDerefOr(machineSet.Spec.Replicas, machineSet.Status.Replicas) > 0 {
 			nodegroups = append(nodegroups, ng)
 		}
 		return nil

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_controller_test.go
@@ -723,6 +723,10 @@ func TestControllerNodeGroups(t *testing.T) {
 	if _, err := controller.nodeGroups(); err == nil {
 		t.Fatalf("expected an error")
 	}
+	if err := deleteTestConfigs(t, controller, machineSetConfigs...); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertNodegroupLen(t, controller, 0)
 
 	// Test #8: machinedeployment with bad scaling bounds results in an error and no nodegroups
 	machineDeploymentConfigs = createMachineDeploymentTestConfigs("MachineDeployment", 2, 1, annotations)
@@ -732,6 +736,24 @@ func TestControllerNodeGroups(t *testing.T) {
 	if _, err := controller.nodeGroups(); err == nil {
 		t.Fatalf("expected an error")
 	}
+	if err := deleteTestConfigs(t, controller, machineDeploymentConfigs...); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertNodegroupLen(t, controller, 0)
+
+	annotations = map[string]string{
+		nodeGroupMinSizeAnnotationKey: "1",
+		nodeGroupMaxSizeAnnotationKey: "5",
+	}
+
+	// Test #9: machineset with nil replicas results in falling back to status count
+	machineSetConfigs = createMachineSetTestConfigs("MachineSet", 1, 1, annotations)
+	machineSetConfigs[0].machineSet.Status.Replicas = *machineSetConfigs[0].machineSet.Spec.Replicas
+	machineSetConfigs[0].machineSet.Spec.Replicas = nil
+	if err := addTestConfigs(t, controller, machineSetConfigs...); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertNodegroupLen(t, controller, 1)
 }
 
 func TestControllerNodeGroupsNodeCount(t *testing.T) {


### PR DESCRIPTION
If a nodegroup cannot scale from zero, and the replicas count is nil, then the nodegroup will be ignored by the autoscaler and won't be scaled. We implemented #143 to prevent allow the autoscaler to continue operating when replicas is nil, but it only works for nodegroups that can scale from zero presently.