### PR TITLE
Revert "[release-4.4] BUG 1835160: Fallback to status if replicas nil in spec"

### DIFF
--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_machinedeployment.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_machinedeployment.go
@@ -23,7 +23,6 @@ import (
 	"github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	machinev1beta1 "github.com/openshift/cluster-api/pkg/client/clientset_generated/clientset/typed/machine/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
 	"k8s.io/utils/pointer"
 )
 
@@ -77,10 +76,7 @@ func (r machineDeploymentScalableResource) Nodes() ([]string, error) {
 }
 
 func (r machineDeploymentScalableResource) Replicas() int32 {
-	if r.machineDeployment.Spec.Replicas == nil {
-		klog.Warningf("MachineDeployment %q has nil spec.replicas. This is unsupported behaviour. Falling back to status.replicas.", r.machineDeployment.Name)
-	}
-	return pointer.Int32PtrDerefOr(r.machineDeployment.Spec.Replicas, r.machineDeployment.Status.Replicas)
+	return pointer.Int32PtrDerefOr(r.machineDeployment.Spec.Replicas, 0)
 }
 
 func (r machineDeploymentScalableResource) SetSize(nreplicas int32) error {

--- a/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_machineset.go
+++ b/cluster-autoscaler/cloudprovider/openshiftmachineapi/machineapi_machineset.go
@@ -23,7 +23,6 @@ import (
 	"github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	machinev1beta1 "github.com/openshift/cluster-api/pkg/client/clientset_generated/clientset/typed/machine/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
 	"k8s.io/utils/pointer"
 )
 
@@ -62,10 +61,7 @@ func (r machineSetScalableResource) Nodes() ([]string, error) {
 }
 
 func (r machineSetScalableResource) Replicas() int32 {
-	if r.machineSet.Spec.Replicas == nil {
-		klog.Warningf("MachineSet %q has nil spec.replicas. This is unsupported behaviour. Falling back to status.replicas.", r.machineSet.Name)
-	}
-	return pointer.Int32PtrDerefOr(r.machineSet.Spec.Replicas, r.machineSet.Status.Replicas)
+	return pointer.Int32PtrDerefOr(r.machineSet.Spec.Replicas, 0)
 }
 
 func (r machineSetScalableResource) SetSize(nreplicas int32) error {


### PR DESCRIPTION
Reverts openshift/kubernetes-autoscaler#153

This fix does not work on 4.4 and would require extra fixes to make it work which, by the time they have gone through 4.6 and backporting to 4.5, would not reach 4.4 in a reasonable time frame. We concluded that it would not be worth backporting this fix because of this