### PR TITLE
Bug 1872080: Add images/cluster-autoscaler/Dockerfile.rhel to match build configuration in ocp-build-data

### DIFF
--- a/images/cluster-autoscaler/Dockerfile.rhel
+++ b/images/cluster-autoscaler/Dockerfile.rhel
@@ -1,0 +1,9 @@
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 AS builder
+WORKDIR /go/src/k8s.io/autoscaler
+COPY . .
+RUN go build -o cluster-autoscaler/cluster-autoscaler ./cluster-autoscaler
+
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
+COPY --from=builder /go/src/k8s.io/autoscaler/cluster-autoscaler/cluster-autoscaler /usr/bin/
+CMD /usr/bin/cluster-autoscaler
+LABEL summary="Cluster Autoscaler for OpenShift and Kubernetes"


### PR DESCRIPTION
This change adds a new Dockerfile.rhel file to control building release
images. It updates the baseimages in the Dockerfile used for promotion
in order to ensure it matches the configuration in the
[ocp-build-data repository](https://github.com/openshift/ocp-build-data/tree/openshift-4.6-rhel-8/images)
used for producing release artifacts.

After this change merges, the release files in
https://github.com/openshift/release/blob/master/ci-operator/config/openshift/kubernetes-autoscaler/openshift-kubernetes-autoscaler-master.yaml
and
https://github.com/openshift/ocp-build-data/blob/openshift-4.6/images/atomic-openshift-cluster-autoscaler.yml
should be updated with the new dockerfile path.