### PR TITLE
BUG 1872080: Add vertical-pod-autoscaler/Dockerfile.rhel to match build configuration in ocp-build-data

### DIFF
--- a/vertical-pod-autoscaler/Dockerfile.rhel
+++ b/vertical-pod-autoscaler/Dockerfile.rhel
@@ -1,0 +1,14 @@
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 AS builder
+WORKDIR /go/src/k8s.io/autoscaler/vertical-pod-autoscaler
+COPY . .
+RUN go build ./pkg/admission-controller
+RUN go build ./pkg/updater
+RUN go build ./pkg/recommender
+
+FROM registry.svc.ci.openshift.org/ocp/4.6:base
+COPY --from=builder \
+    /go/src/k8s.io/autoscaler/vertical-pod-autoscaler/admission-controller \
+    /go/src/k8s.io/autoscaler/vertical-pod-autoscaler/updater \
+    /go/src/k8s.io/autoscaler/vertical-pod-autoscaler/recommender \
+    /usr/bin/
+LABEL summary="Vertical Pod Autoscaler for OpenShift and Kubernetes"


### PR DESCRIPTION
This change adds a new Dockerfile.rhel file to control building release
images. It updates the baseimages in the Dockerfile used for promotion
in order to ensure it matches the configuration in the
[ocp-build-data
repository](https://github.com/openshift/ocp-build-data/tree/openshift-4.6-rhel-8/images)
used for producing release artifacts.

After this change merges, the release files in
https://github.com/openshift/release/blob/master/ci-operator/config/openshift/kubernetes-autoscaler/openshift-kubernetes-autoscaler-master.yaml
and
https://github.com/openshift/ocp-build-data/blob/openshift-4.6/images/vertical-pod-autoscaler.yml
should be updated with the new dockerfile path.