### PR TITLE
Updating atomic-openshift-cluster-autoscaler builder & base images to be consistent with ART

### DIFF
--- a/images/cluster-autoscaler/Dockerfile.rhel
+++ b/images/cluster-autoscaler/Dockerfile.rhel
@@ -1,9 +1,9 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/k8s.io/autoscaler
 COPY . .
 RUN go build -o cluster-autoscaler/cluster-autoscaler ./cluster-autoscaler
 
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift
 COPY --from=builder /go/src/k8s.io/autoscaler/cluster-autoscaler/cluster-autoscaler /usr/bin/
 CMD /usr/bin/cluster-autoscaler
 LABEL summary="Cluster Autoscaler for OpenShift and Kubernetes"


### PR DESCRIPTION
Updating atomic-openshift-cluster-autoscaler builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/atomic-openshift-cluster-autoscaler.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
