### PR TITLE
Updating vertical-pod-autoscaler builder & base images to be consistent with ART

### DIFF
--- a/vertical-pod-autoscaler/Dockerfile.rhel
+++ b/vertical-pod-autoscaler/Dockerfile.rhel
@@ -1,11 +1,11 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/k8s.io/autoscaler/vertical-pod-autoscaler
 COPY . .
 RUN go build ./pkg/admission-controller
 RUN go build ./pkg/updater
 RUN go build ./pkg/recommender
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 COPY --from=builder \
     /go/src/k8s.io/autoscaler/vertical-pod-autoscaler/admission-controller \
     /go/src/k8s.io/autoscaler/vertical-pod-autoscaler/updater \


### PR DESCRIPTION
Updating vertical-pod-autoscaler builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/vertical-pod-autoscaler.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.