### PR TITLE
Bug 1891551: Ensure the node template include up to date and informative labels

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -70,12 +70,12 @@ func mustCreateTestController(t *testing.T, testConfigs ...*testConfig) (*machin
 		}
 
 		for i := range config.machines {
-			machineObjects = append(machineObjects, newUnstructuredFromMachine(config.machines[i]))
+			machineObjects = append(machineObjects, newUnstructuredFrom(config.machines[i]))
 		}
 
-		machineObjects = append(machineObjects, newUnstructuredFromMachineSet(config.machineSet))
+		machineObjects = append(machineObjects, newUnstructuredFrom(config.machineSet))
 		if config.machineDeployment != nil {
-			machineObjects = append(machineObjects, newUnstructuredFromMachineDeployment(config.machineDeployment))
+			machineObjects = append(machineObjects, newUnstructuredFrom(config.machineDeployment))
 		}
 	}
 
@@ -286,15 +286,15 @@ func addTestConfigs(t *testing.T, controller *machineController, testConfigs ...
 	for _, config := range testConfigs {
 		if config.machineDeployment != nil {
 
-			if err := controller.machineDeploymentInformer.Informer().GetStore().Add(newUnstructuredFromMachineDeployment(config.machineDeployment)); err != nil {
+			if err := controller.machineDeploymentInformer.Informer().GetStore().Add(newUnstructuredFrom(config.machineDeployment)); err != nil {
 				return err
 			}
 		}
-		if err := controller.machineSetInformer.Informer().GetStore().Add(newUnstructuredFromMachineSet(config.machineSet)); err != nil {
+		if err := controller.machineSetInformer.Informer().GetStore().Add(newUnstructuredFrom(config.machineSet)); err != nil {
 			return err
 		}
 		for i := range config.machines {
-			if err := controller.machineInformer.Informer().GetStore().Add(newUnstructuredFromMachine(config.machines[i])); err != nil {
+			if err := controller.machineInformer.Informer().GetStore().Add(newUnstructuredFrom(config.machines[i])); err != nil {
 				return err
 			}
 		}
@@ -631,7 +631,7 @@ func TestControllerNodeGroupForNodeWithMissingMachineOwner(t *testing.T) {
 
 		machine := testConfig.machines[0].DeepCopy()
 		machine.OwnerReferences = []v1.OwnerReference{}
-		if err := controller.machineInformer.Informer().GetStore().Update(newUnstructuredFromMachine(machine)); err != nil {
+		if err := controller.machineInformer.Informer().GetStore().Update(newUnstructuredFrom(machine)); err != nil {
 			t.Fatalf("unexpected error updating machine, got %v", err)
 		}
 
@@ -889,7 +889,7 @@ func TestControllerFindMachineFromNodeAnnotation(t *testing.T) {
 	// searching using the annotation on the node object.
 	for _, machine := range testConfig.machines {
 		machine.Spec.ProviderID = nil
-		if err := controller.machineInformer.Informer().GetStore().Update(newUnstructuredFromMachine(machine)); err != nil {
+		if err := controller.machineInformer.Informer().GetStore().Update(newUnstructuredFrom(machine)); err != nil {
 			t.Fatalf("unexpected error updating machine, got %v", err)
 		}
 	}
@@ -934,13 +934,13 @@ func TestControllerMachineSetNodeNamesWithoutLinkage(t *testing.T) {
 	// Remove all linkage between node and machine.
 	for _, machine := range testConfig.machines {
 		machine.Spec.ProviderID = nil
-		if err := controller.machineInformer.Informer().GetStore().Update(newUnstructuredFromMachine(machine)); err != nil {
+		if err := controller.machineInformer.Informer().GetStore().Update(newUnstructuredFrom(machine)); err != nil {
 			t.Fatalf("unexpected error updating machine, got %v", err)
 		}
 	}
 	for _, machine := range testConfig.machines {
 		machine.Status.NodeRef = nil
-		if err := controller.machineInformer.Informer().GetStore().Update(newUnstructuredFromMachine(machine)); err != nil {
+		if err := controller.machineInformer.Informer().GetStore().Update(newUnstructuredFrom(machine)); err != nil {
 			t.Fatalf("unexpected error updating machine, got %v", err)
 		}
 	}
@@ -980,7 +980,7 @@ func TestControllerMachineSetNodeNamesUsingProviderID(t *testing.T) {
 	// ID for lookups.
 	for _, machine := range testConfig.machines {
 		machine.Status.NodeRef = nil
-		if err := controller.machineInformer.Informer().GetStore().Update(newUnstructuredFromMachine(machine)); err != nil {
+		if err := controller.machineInformer.Informer().GetStore().Update(newUnstructuredFrom(machine)); err != nil {
 			t.Fatalf("unexpected error updating machine, got %v", err)
 		}
 	}
@@ -1029,7 +1029,7 @@ func TestControllerMachineSetNodeNamesUsingStatusNodeRefName(t *testing.T) {
 	// searching using Status.NodeRef.Name.
 	for _, machine := range testConfig.machines {
 		machine.Spec.ProviderID = nil
-		if err := controller.machineInformer.Informer().GetStore().Update(newUnstructuredFromMachine(machine)); err != nil {
+		if err := controller.machineInformer.Informer().GetStore().Update(newUnstructuredFrom(machine)); err != nil {
 			t.Fatalf("unexpected error updating machine, got %v", err)
 		}
 	}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_converters.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_converters.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 )
 
@@ -182,77 +183,10 @@ func newMachineFromUnstructured(u *unstructured.Unstructured) *Machine {
 	return &machine
 }
 
-func newUnstructuredFromMachineSet(m *MachineSet) *unstructured.Unstructured {
-	u := unstructured.Unstructured{}
-
-	u.SetAPIVersion(m.APIVersion)
-	u.SetAnnotations(m.Annotations)
-	u.SetKind(m.Kind)
-	u.SetLabels(m.Labels)
-	u.SetName(m.Name)
-	u.SetNamespace(m.Namespace)
-	u.SetOwnerReferences(m.OwnerReferences)
-	u.SetUID(m.UID)
-	u.SetDeletionTimestamp(m.DeletionTimestamp)
-
-	if m.Spec.Replicas != nil {
-		unstructured.SetNestedField(u.Object, int64(*m.Spec.Replicas), "spec", "replicas")
+func newUnstructuredFrom(obj runtime.Object) *unstructured.Unstructured {
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		panic(err)
 	}
-	unstructured.SetNestedField(u.Object, int64(m.Status.Replicas), "status", "replicas")
-
-	return &u
-}
-
-func newUnstructuredFromMachineDeployment(m *MachineDeployment) *unstructured.Unstructured {
-	u := unstructured.Unstructured{}
-
-	u.SetAPIVersion(m.APIVersion)
-	u.SetAnnotations(m.Annotations)
-	u.SetKind(m.Kind)
-	u.SetLabels(m.Labels)
-	u.SetName(m.Name)
-	u.SetNamespace(m.Namespace)
-	u.SetOwnerReferences(m.OwnerReferences)
-	u.SetUID(m.UID)
-	u.SetDeletionTimestamp(m.DeletionTimestamp)
-
-	if m.Spec.Replicas != nil {
-		unstructured.SetNestedField(u.Object, int64(*m.Spec.Replicas), "spec", "replicas")
-	}
-	unstructured.SetNestedField(u.Object, int64(m.Status.Replicas), "status", "replicas")
-
-	return &u
-}
-
-func newUnstructuredFromMachine(m *Machine) *unstructured.Unstructured {
-	u := unstructured.Unstructured{}
-
-	u.SetAPIVersion(m.APIVersion)
-	u.SetAnnotations(m.Annotations)
-	u.SetKind(m.Kind)
-	u.SetLabels(m.Labels)
-	u.SetName(m.Name)
-	u.SetNamespace(m.Namespace)
-	u.SetOwnerReferences(m.OwnerReferences)
-	u.SetUID(m.UID)
-	u.SetDeletionTimestamp(m.DeletionTimestamp)
-
-	if m.Spec.ProviderID != nil && *m.Spec.ProviderID != "" {
-		unstructured.SetNestedField(u.Object, *m.Spec.ProviderID, "spec", "providerID")
-	}
-
-	if m.Status.NodeRef != nil {
-		if m.Status.NodeRef.Kind != "" {
-			unstructured.SetNestedField(u.Object, m.Status.NodeRef.Kind, "status", "nodeRef", "kind")
-		}
-		if m.Status.NodeRef.Name != "" {
-			unstructured.SetNestedField(u.Object, m.Status.NodeRef.Name, "status", "nodeRef", "name")
-		}
-	}
-
-	if m.Status.ErrorMessage != nil {
-		unstructured.SetNestedField(u.Object, *m.Status.ErrorMessage, "status", "errorMessage")
-	}
-
-	return &u
+	return &unstructured.Unstructured{Object: u}
 }

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machineset.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_machineset.go
@@ -140,7 +140,7 @@ func newMachineSetScalableResource(controller *machineController, machineSet *Ma
 }
 
 func (r machineSetScalableResource) Labels() map[string]string {
-	return r.machineSet.Spec.Template.Spec.Labels
+	return r.machineSet.Spec.Template.Spec.ObjectMeta.Labels
 }
 
 func (r machineSetScalableResource) Taints() []apiv1.Taint {

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -370,7 +370,11 @@ func buildGenericLabels(nodeName string) map[string]string {
 	// labels are used for, or remove them if not necessary
 	m := make(map[string]string)
 	m[kubeletapis.LabelArch] = cloudprovider.DefaultArch
+	m[corev1.LabelArchStable] = cloudprovider.DefaultArch
+
 	m[kubeletapis.LabelOS] = cloudprovider.DefaultOS
+	m[corev1.LabelOSStable] = cloudprovider.DefaultOS
+
 	m[corev1.LabelHostname] = nodeName
 	return m
 }


### PR DESCRIPTION
This should resolve issues where nodegroups are scaling from zero and need to schedule pods based on some well known labels that are applied to nodes.

We have discovered that if there are no healthy nodes within a node group (eg they are all cordoned) then this also counts as scaling from zero in the eyes of the autoscaler, so there is actually a chance we can copy labels from a node that exists, hence this has also been added.

There are a few options we could consider in this solution:
- Copying all labels from the existing node and not using the machinset/generic labels in that case
- Having the nodegroup store a copy of valid node labels from a node that it has seen in the past to improve the scale from zero experience when there genuinely are no nodes available to get labels from

I will add unit tests to this before we merge