### PR TITLE
Bug 1955324: update testing scripts to use go 1.16

### DIFF
--- a/hack/go-fmt.sh
+++ b/hack/go-fmt.sh
@@ -13,6 +13,6 @@ else
     --workdir "/go/src/github.com/openshift/${REPO_NAME}" \
     --env GO111MODULE="$GO111MODULE" \
     --env GOFLAGS="$GOFLAGS" \
-    openshift/origin-release:golang-1.13 \
+    openshift/origin-release:golang-1.16 \
     ./hack/go-fmt.sh "${@}"
 fi

--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -11,6 +11,6 @@ else
     --workdir "/go/src/github.com/openshift/${REPO_NAME}" \
     --env GO111MODULE="$GO111MODULE" \
     --env GOFLAGS="$GOFLAGS" \
-    openshift/origin-release:golang-1.13 \
+    openshift/origin-release:golang-1.16 \
     ./hack/go-lint.sh "${@}"
 fi

--- a/hack/go-vet.sh
+++ b/hack/go-vet.sh
@@ -9,6 +9,6 @@ else
     --workdir "/go/src/k8s.io/autoscaler" \
     --env GO111MODULE="$GO111MODULE" \
     --env GOFLAGS="$GOFLAGS" \
-    openshift/origin-release:golang-1.13 \
+    openshift/origin-release:golang-1.16 \
     ./hack/go-vet.sh "${@}"
 fi

--- a/hack/goimports.sh
+++ b/hack/goimports.sh
@@ -11,6 +11,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/sigs.k8s.io/${REPO_NAME}:z" \
     --workdir "/go/src/sigs.k8s.io/${REPO_NAME}" \
-    openshift/origin-release:golang-1.13 \
+    openshift/origin-release:golang-1.16 \
     ./hack/goimports.sh "${@}"
 fi


### PR DESCRIPTION
Some of our tests (eg vet) are failing due to the age of the golang
version that is used for the containers. This change updates the version
to 1.16.