### PR TITLE
Bug 1948719: updating CA version to 1.21.0

### DIFF
--- a/cluster-autoscaler/version/version.go
+++ b/cluster-autoscaler/version/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package version
 
 // ClusterAutoscalerVersion contains version of CA.
-const ClusterAutoscalerVersion = "1.20.0"
+const ClusterAutoscalerVersion = "1.21.0"


### PR DESCRIPTION
this commit was late in landing upstream, adding it now to make sure we have the proper version in the binary