### PR TITLE
Bug 1991496: add clusterapi build tags to dockerfiles

### DIFF
--- a/images/cluster-autoscaler/Dockerfile
+++ b/images/cluster-autoscaler/Dockerfile
@@ -1,6 +1,10 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
 WORKDIR /go/src/k8s.io/autoscaler
 COPY . .
-RUN go build -o cluster-autoscaler/cluster-autoscaler ./cluster-autoscaler
+WORKDIR /go/src/k8s.io/autoscaler/cluster-autoscaler
+RUN go build --tags clusterapi -o ./cluster-autoscaler .
 
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+COPY --from=builder /go/src/k8s.io/autoscaler/cluster-autoscaler/cluster-autoscaler /usr/bin/
 CMD /usr/bin/cluster-autoscaler
+LABEL summary="Cluster Autoscaler for OpenShift and Kubernetes"

--- a/images/cluster-autoscaler/Dockerfile.rhel
+++ b/images/cluster-autoscaler/Dockerfile.rhel
@@ -2,7 +2,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.10 AS 
 WORKDIR /go/src/k8s.io/autoscaler
 COPY . .
 WORKDIR /go/src/k8s.io/autoscaler/cluster-autoscaler
-RUN go build -o ./cluster-autoscaler .
+RUN go build --tags clusterapi -o ./cluster-autoscaler .
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.10
 COPY --from=builder /go/src/k8s.io/autoscaler/cluster-autoscaler/cluster-autoscaler /usr/bin/


### PR DESCRIPTION
This change adds build tags to the dockerfiles for the cluster
autoscaler. This tag will restrict the binary to only contain the
clusterapi provider.

Additionally, the community facing dockerfile has been updated to build
from public/ubi sources, go lang 1.16, and more closely matches the rhel
version.

*NOTE* this commit should be squashed into the primary OpenShift commit
that configures the repository, ref:
c681f96ed154f698bce4546b07fe8e9ce1ea7196