### PR TITLE
Bug 2045561: revert defaultCAPIGroup constant

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -44,7 +44,7 @@ import (
 const (
 	machineProviderIDIndex = "machineProviderIDIndex"
 	nodeProviderIDIndex    = "nodeProviderIDIndex"
-	defaultCAPIGroup       = "machine.openshift.io"
+	defaultCAPIGroup       = "cluster.x-k8s.io"
 	// CAPIGroupEnvVar contains the environment variable name which allows overriding defaultCAPIGroup.
 	CAPIGroupEnvVar               = "CAPI_GROUP"
 	resourceNameMachine           = "machines"

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
@@ -911,6 +911,11 @@ func Test_clusterNameFromResource(t *testing.T) {
 }
 
 func Test_getKeyHelpers(t *testing.T) {
+	// unset the environment variable to ensure we get the default from the code
+	if err := os.Setenv(CAPIGroupEnvVar, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
 	for _, tc := range []struct {
 		name     string
 		expected string


### PR DESCRIPTION
During the most recent rebase of the autoscaler, this constant was
overwritten. This patch is being added to revert the original state of
the constant.

TODO: during the next rebase of the autoscaler, this commit should be
dropped in favor of taking the upstream constant directly. This may
involve modifying a previous carry commit to include the upstream
value.
