### PR TITLE
add user configurable cluster api version

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/README.md
+++ b/cluster-autoscaler/cloudprovider/clusterapi/README.md
@@ -180,6 +180,23 @@ the machine annotation on nodes will be `test.8s.io/machine`, the machine deleti
 annotation will be `test.k8s.io/delete-machine`, and the cluster name label will be
 `test.k8s.io/cluster-name`.
 
+## Specifying a Custom Resource Version
+
+When determining the group version for the Cluster API types, by default the autoscaler
+will look for the latest version of the group. For example, if `MachineDeployments`
+exist in the `cluster.x-k8s.io` group at versions `v1alpha1` and `v1beta1`, the
+autoscaler will choose `v1beta1`.
+
+In some cases it may be desirable to specify which version of the API the cluster
+autoscaler should use. This can be useful in debugging scenarios, or in situations
+where you have deployed multiple API versions and wish to ensure that the autoscaler
+uses a specific version.
+
+Setting the `CAPI_VERSION` environment variable will instruct the autoscaler to use
+the version specified. This works in a similar fashion as the API group environment
+variable with the exception that there is no default value. When this variable is not
+set, the autoscaler will use the behavior described above.
+
 ## Sample manifest
 
 A sample manifest that will create a deployment running the autoscaler is

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -1395,6 +1395,26 @@ func TestControllerGetAPIVersionGroup(t *testing.T) {
 	}
 }
 
+func TestControllerGetAPIVersion(t *testing.T) {
+	expected := "v1beta1"
+	if err := os.Setenv(CAPIVersionEnvVar, expected); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	observed := getCAPIVersion()
+	if observed != expected {
+		t.Fatalf("Wrong API Version detected, expected %q, got %q", expected, observed)
+	}
+
+	if err := os.Unsetenv(CAPIVersionEnvVar); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected = ""
+	observed = getCAPIVersion()
+	if observed != expected {
+		t.Fatalf("Wrong API Version detected, expected %q, got %q", expected, observed)
+	}
+}
+
 func TestControllerGetAPIVersionGroupWithMachineDeployments(t *testing.T) {
 	testConfig := createMachineDeploymentTestConfig(RandomString(6), RandomString(6), RandomString(6), 1, map[string]string{
 		nodeGroupMinSizeAnnotationKey: "1",
@@ -1450,28 +1470,40 @@ func TestControllerGetAPIVersionGroupWithMachineDeployments(t *testing.T) {
 }
 
 func TestGetAPIGroupPreferredVersion(t *testing.T) {
+	customVersion := "v1"
 	testCases := []struct {
 		description      string
 		APIGroup         string
 		preferredVersion string
+		envVar           string
 		error            bool
 	}{
 		{
 			description:      "find version for default API group",
 			APIGroup:         defaultCAPIGroup,
 			preferredVersion: "v1beta1",
+			envVar:           "",
 			error:            false,
 		},
 		{
 			description:      "find version for another API group",
 			APIGroup:         customCAPIGroup,
 			preferredVersion: "v1beta1",
+			envVar:           "",
+			error:            false,
+		},
+		{
+			description:      "find version for another API group while overriding version with env var",
+			APIGroup:         customCAPIGroup,
+			preferredVersion: customVersion,
+			envVar:           customVersion,
 			error:            false,
 		},
 		{
 			description:      "API group does not exist",
 			APIGroup:         "does.not.exist",
 			preferredVersion: "",
+			envVar:           "",
 			error:            true,
 		},
 	}
@@ -1485,11 +1517,23 @@ func TestGetAPIGroupPreferredVersion(t *testing.T) {
 				{
 					GroupVersion: fmt.Sprintf("%s/v1beta1", defaultCAPIGroup),
 				},
+				{
+					GroupVersion: fmt.Sprintf("%s/%s", customCAPIGroup, customVersion),
+				},
 			},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
+			if tc.envVar == "" {
+				if err := os.Unsetenv(CAPIVersionEnvVar); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			} else {
+				if err := os.Setenv(CAPIVersionEnvVar, tc.envVar); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
 			version, err := getAPIGroupPreferredVersion(discoveryClient, tc.APIGroup)
 			if (err != nil) != tc.error {
 				t.Errorf("expected to have error: %t. Had an error: %t", tc.error, err != nil)
@@ -1498,6 +1542,10 @@ func TestGetAPIGroupPreferredVersion(t *testing.T) {
 				t.Errorf("expected %v, got: %v", tc.preferredVersion, version)
 			}
 		})
+	}
+
+	if err := os.Unsetenv(CAPIVersionEnvVar); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
This change introduces an environment variable, `CAPI_VERSION`, through
which a user can set the API version for the group they are using. This
change is being added to address situations where a user might have
multiple API versions for the cluster api group and wishes to be
explicit about which version is selected.

Also adds unit tests and documentation for the new behavior. This change
does not break the existing behavior.