### PR TITLE
Bug 2066270: UPSTREAM: <carry>: Fallback to CAPI annotations

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -33,8 +33,7 @@ import (
 )
 
 const (
-	// deprecatedMachineDeleteAnnotationKey should not be removed until minimum cluster-api support is v1alpha3
-	deprecatedMachineDeleteAnnotationKey = "cluster.k8s.io/delete-machine"
+	capiMachineDeleteAnnotationKey = "cluster.x-k8s.io/delete-machine"
 	// TODO: determine what currently relies on deprecatedMachineAnnotationKey to determine when it can be removed
 	deprecatedMachineAnnotationKey = "cluster.k8s.io/machine"
 	machineDeleteAnnotationKey     = "machine.openshift.io/cluster-api-delete-machine"

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -648,8 +648,8 @@ func TestNodeGroupDeleteNodes(t *testing.T) {
 			if _, found := machine.GetAnnotations()[machineDeleteAnnotationKey]; !found {
 				t.Errorf("expected annotation %q on machine %s", machineDeleteAnnotationKey, machine.GetName())
 			}
-			if _, found := machine.GetAnnotations()[deprecatedMachineDeleteAnnotationKey]; !found {
-				t.Errorf("expected annotation %q on machine %s", deprecatedMachineDeleteAnnotationKey, machine.GetName())
+			if _, found := machine.GetAnnotations()[capiMachineDeleteAnnotationKey]; !found {
+				t.Errorf("expected annotation %q on machine %s", capiMachineDeleteAnnotationKey, machine.GetName())
 			}
 		}
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -132,7 +132,7 @@ func (r unstructuredScalableResource) UnmarkMachineForDeletion(machine *unstruct
 
 	annotations := u.GetAnnotations()
 	delete(annotations, machineDeleteAnnotationKey)
-	delete(annotations, deprecatedMachineDeleteAnnotationKey)
+	delete(annotations, capiMachineDeleteAnnotationKey)
 	u.SetAnnotations(annotations)
 	_, updateErr := r.controller.managementClient.Resource(r.controller.machineResource).Namespace(u.GetNamespace()).Update(context.TODO(), u, metav1.UpdateOptions{})
 
@@ -153,7 +153,7 @@ func (r unstructuredScalableResource) MarkMachineForDeletion(machine *unstructur
 	}
 
 	annotations[machineDeleteAnnotationKey] = time.Now().String()
-	annotations[deprecatedMachineDeleteAnnotationKey] = time.Now().String()
+	annotations[capiMachineDeleteAnnotationKey] = time.Now().String()
 	u.SetAnnotations(annotations)
 
 	_, updateErr := r.controller.managementClient.Resource(r.controller.machineResource).Namespace(u.GetNamespace()).Update(context.TODO(), u, metav1.UpdateOptions{})

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
@@ -29,12 +29,12 @@ import (
 )
 
 const (
-	deprecatedNodeGroupMinSizeAnnotationKey = "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size"
-	deprecatedNodeGroupMaxSizeAnnotationKey = "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size"
-	nodeGroupMinSizeAnnotationKey           = "machine.openshift.io/cluster-api-autoscaler-node-group-min-size"
-	nodeGroupMaxSizeAnnotationKey           = "machine.openshift.io/cluster-api-autoscaler-node-group-max-size"
-	clusterNameLabel                        = "machine.openshift.io/cluster-name"
-	deprecatedClusterNameLabel              = "cluster.k8s.io/cluster-name"
+	capiNodeGroupMinSizeAnnotationKey = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size"
+	capiNodeGroupMaxSizeAnnotationKey = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size"
+	nodeGroupMinSizeAnnotationKey     = "machine.openshift.io/cluster-api-autoscaler-node-group-min-size"
+	nodeGroupMaxSizeAnnotationKey     = "machine.openshift.io/cluster-api-autoscaler-node-group-max-size"
+	clusterNameLabel                  = "machine.openshift.io/cluster-name"
+	capiClusterNameLabel              = "cluster.x-k8s.io/cluster-name"
 
 	cpuKey     = "machine.openshift.io/vCPU"
 	memoryKey  = "machine.openshift.io/memoryMb"
@@ -73,7 +73,7 @@ type normalizedProviderID string
 func minSize(annotations map[string]string) (int, error) {
 	val, found := annotations[nodeGroupMinSizeAnnotationKey]
 	if !found {
-		val, found = annotations[deprecatedNodeGroupMinSizeAnnotationKey]
+		val, found = annotations[capiNodeGroupMinSizeAnnotationKey]
 	}
 	if !found {
 		return 0, errMissingMinAnnotation
@@ -92,7 +92,7 @@ func minSize(annotations map[string]string) (int, error) {
 func maxSize(annotations map[string]string) (int, error) {
 	val, found := annotations[nodeGroupMaxSizeAnnotationKey]
 	if !found {
-		val, found = annotations[deprecatedNodeGroupMaxSizeAnnotationKey]
+		val, found = annotations[capiNodeGroupMaxSizeAnnotationKey]
 	}
 	if !found {
 		return 0, errMissingMaxAnnotation
@@ -219,15 +219,15 @@ func clusterNameFromResource(r *unstructured.Unstructured) string {
 		return clusterName
 	}
 
-	// fallback for backward compatibility for deprecatedClusterNameLabel
-	if clusterName, ok := r.GetLabels()[deprecatedClusterNameLabel]; ok {
+	// fallback for backward compatibility for capiClusterNameLabel
+	if clusterName, ok := r.GetLabels()[capiClusterNameLabel]; ok {
 		return clusterName
 	}
 
 	// fallback for cluster-api v1alpha1 cluster linking
 	templateLabels, found, err := unstructured.NestedStringMap(r.UnstructuredContent(), "spec", "template", "metadata", "labels")
 	if found {
-		if clusterName, ok := templateLabels[deprecatedClusterNameLabel]; ok {
+		if clusterName, ok := templateLabels[capiClusterNameLabel]; ok {
 			return clusterName
 		}
 	}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
@@ -115,20 +115,20 @@ func TestUtilParseScalingBounds(t *testing.T) {
 		min: 0,
 		max: 1,
 	}, {
-		description: "deprecated min/max annotations still work, result is min 0, max 1",
+		description: "CAPI min/max annotations still work, result is min 0, max 1",
 		annotations: map[string]string{
-			deprecatedNodeGroupMinSizeAnnotationKey: "0",
-			deprecatedNodeGroupMaxSizeAnnotationKey: "1",
+			capiNodeGroupMinSizeAnnotationKey: "0",
+			capiNodeGroupMaxSizeAnnotationKey: "1",
 		},
 		min: 0,
 		max: 1,
 	}, {
-		description: "deprecated min/max annotations do not take precedence over non-deprecated annotations, result is min 1, max 2",
+		description: "CAPI min/max annotations do not take precedence over MAPI annotations, result is min 1, max 2",
 		annotations: map[string]string{
-			deprecatedNodeGroupMinSizeAnnotationKey: "0",
-			deprecatedNodeGroupMaxSizeAnnotationKey: "1",
-			nodeGroupMinSizeAnnotationKey:           "1",
-			nodeGroupMaxSizeAnnotationKey:           "2",
+			capiNodeGroupMinSizeAnnotationKey: "0",
+			capiNodeGroupMaxSizeAnnotationKey: "1",
+			nodeGroupMinSizeAnnotationKey:     "1",
+			nodeGroupMaxSizeAnnotationKey:     "2",
 		},
 		min: 1,
 		max: 2,
@@ -710,7 +710,7 @@ func Test_clusterNameFromResource(t *testing.T) {
 					"name":      "foo",
 					"namespace": "default",
 					"labels": map[string]interface{}{
-						deprecatedClusterNameLabel: "bar",
+						capiClusterNameLabel: "bar",
 					},
 				},
 				"spec": map[string]interface{}{
@@ -730,7 +730,7 @@ func Test_clusterNameFromResource(t *testing.T) {
 					"name":      "foo",
 					"namespace": "default",
 					"labels": map[string]interface{}{
-						deprecatedClusterNameLabel: "bar",
+						capiClusterNameLabel: "bar",
 					},
 				},
 				"spec": map[string]interface{}{
@@ -755,7 +755,7 @@ func Test_clusterNameFromResource(t *testing.T) {
 					"template": map[string]interface{}{
 						"metadata": map[string]interface{}{
 							"labels": map[string]interface{}{
-								deprecatedClusterNameLabel: "bar",
+								capiClusterNameLabel: "bar",
 							},
 						},
 					},
@@ -779,7 +779,7 @@ func Test_clusterNameFromResource(t *testing.T) {
 					"template": map[string]interface{}{
 						"metadata": map[string]interface{}{
 							"labels": map[string]interface{}{
-								deprecatedClusterNameLabel: "bar",
+								capiClusterNameLabel: "bar",
 							},
 						},
 					},


### PR DESCRIPTION
This is to ensure the CAPI provider has the upstream CAPI annotations so it can be used with CAPI in hypershift.

cherry-picks https://github.com/openshift/kubernetes-autoscaler/pull/214
#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
