### PR TITLE
Bug 2087037: revert defaultCAPIGroup constant

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -44,7 +44,7 @@ import (
 const (
 	machineProviderIDIndex = "machineProviderIDIndex"
 	nodeProviderIDIndex    = "nodeProviderIDIndex"
-	defaultCAPIGroup       = "machine.openshift.io"
+	defaultCAPIGroup       = "cluster.x-k8s.io"
 	// CAPIGroupEnvVar contains the environment variable name which allows overriding defaultCAPIGroup.
 	CAPIGroupEnvVar = "CAPI_GROUP"
 	// CAPIVersionEnvVar contains the environment variable name which allows overriding the Cluster API group version.


### PR DESCRIPTION
During the most recent rebase of the autoscaler, this constant was
overwritten. This patch is being added to revert the original state of
the constant.

TODO: during the next rebase of the autoscaler, this commit should be
dropped in favor of taking the upstream constant directly. This may
involve modifying a previous carry commit to include the upstream
value.

NOTE: This was dropped in the current rebase, but the message in the commit was not read, we need to make sure we handle this next time

CC @elmiko @enxebre @Fedosin 

