### PR TITLE
Bug 2087037: UPSTREAM: <drop>: Fix annotations to work with CAPI

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -33,13 +33,7 @@ import (
 )
 
 const (
-	// deprecatedMachineDeleteAnnotationKey should not be removed until minimum cluster-api support is v1alpha3
-	deprecatedMachineDeleteAnnotationKey = "cluster.k8s.io/delete-machine"
-	// TODO: determine what currently relies on deprecatedMachineAnnotationKey to determine when it can be removed
-	deprecatedMachineAnnotationKey = "cluster.k8s.io/machine"
-	machineDeleteAnnotationKey     = "machine.openshift.io/cluster-api-delete-machine"
-	machineAnnotationKey           = "machine.openshift.io/machine"
-	debugFormat                    = "%s (min: %d, max: %d, replicas: %d)"
+	debugFormat = "%s (min: %d, max: %d, replicas: %d)"
 
 	// This default for the maximum number of pods comes from the machine-config-operator
 	// see https://github.com/openshift/machine-config-operator/blob/2f1bd6d99131fa4471ed95543a51dec3d5922b2b/templates/worker/01-worker-kubelet/_base/files/kubelet.yaml#L19

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -687,9 +687,6 @@ func TestNodeGroupDeleteNodes(t *testing.T) {
 			if _, found := machine.GetAnnotations()[machineDeleteAnnotationKey]; !found {
 				t.Errorf("expected annotation %q on machine %s", machineDeleteAnnotationKey, machine.GetName())
 			}
-			if _, found := machine.GetAnnotations()[deprecatedMachineDeleteAnnotationKey]; !found {
-				t.Errorf("expected annotation %q on machine %s", deprecatedMachineDeleteAnnotationKey, machine.GetName())
-			}
 		}
 
 		gvr, err := ng.scalableResource.GroupVersionResource()

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -138,7 +138,7 @@ func (r unstructuredScalableResource) UnmarkMachineForDeletion(machine *unstruct
 
 	annotations := u.GetAnnotations()
 	delete(annotations, machineDeleteAnnotationKey)
-	delete(annotations, deprecatedMachineDeleteAnnotationKey)
+	delete(annotations, oldMachineDeleteAnnotationKey)
 	u.SetAnnotations(annotations)
 	_, updateErr := r.controller.managementClient.Resource(r.controller.machineResource).Namespace(u.GetNamespace()).Update(context.TODO(), u, metav1.UpdateOptions{})
 
@@ -159,7 +159,7 @@ func (r unstructuredScalableResource) MarkMachineForDeletion(machine *unstructur
 	}
 
 	annotations[machineDeleteAnnotationKey] = time.Now().String()
-	annotations[deprecatedMachineDeleteAnnotationKey] = time.Now().String()
+	annotations[oldMachineDeleteAnnotationKey] = time.Now().String()
 	u.SetAnnotations(annotations)
 
 	_, updateErr := r.controller.managementClient.Resource(r.controller.machineResource).Namespace(u.GetNamespace()).Update(context.TODO(), u, metav1.UpdateOptions{})

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
@@ -31,9 +31,11 @@ import (
 const (
 	deprecatedNodeGroupMinSizeAnnotationKey = "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size"
 	deprecatedNodeGroupMaxSizeAnnotationKey = "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size"
-	nodeGroupMinSizeAnnotationKey           = "machine.openshift.io/cluster-api-autoscaler-node-group-min-size"
-	nodeGroupMaxSizeAnnotationKey           = "machine.openshift.io/cluster-api-autoscaler-node-group-max-size"
 	deprecatedClusterNameLabel              = "cluster.k8s.io/cluster-name"
+
+	// TODO: update machine API operator to match CAPI annotation so this can be inferred dynamically by getMachineDeleteAnnotationKey i.e ${apigroup}/delete-machine
+	// https://github.com/openshift/machine-api-operator/blob/128c5c90918c009172c6d24d5715888e0e1d59e4/pkg/controller/machineset/delete_policy.go#L34
+	oldMachineDeleteAnnotationKey = "machine.openshift.io/cluster-api-delete-machine"
 
 	cpuKey     = "machine.openshift.io/vCPU"
 	memoryKey  = "machine.openshift.io/memoryMb"
@@ -66,6 +68,23 @@ var (
 	errInvalidMaxAnnotation = errors.New("invalid max annotation")
 
 	zeroQuantity = resource.MustParse("0")
+
+	// machineDeleteAnnotationKey is the annotation used by cluster-api to indicate
+	// that a machine should be deleted. Because this key can be affected by the
+	// CAPI_GROUP env variable, it is initialized here.
+	machineDeleteAnnotationKey = getMachineDeleteAnnotationKey()
+
+	// machineAnnotationKey is the annotation used by the cluster-api on Node objects
+	// to specify the name of the related Machine object. Because this can be affected
+	// by the CAPI_GROUP env variable, it is initialized here.
+	machineAnnotationKey = getMachineAnnotationKey()
+
+	// nodeGroupMinSizeAnnotationKey and nodeGroupMaxSizeAnnotationKey are the keys
+	// used in MachineSet and MachineDeployment annotations to specify the limits
+	// for the node group. Because the keys can be affected by the CAPI_GROUP env
+	// variable, they are initialized here.
+	nodeGroupMinSizeAnnotationKey = getNodeGroupMinSizeAnnotationKey()
+	nodeGroupMaxSizeAnnotationKey = getNodeGroupMaxSizeAnnotationKey()
 )
 
 type normalizedProviderID string


### PR DESCRIPTION
This [https://github.com/openshift/kubernetes-autoscaler/commit/573eacd153c3e5b45bc18879a3c9b01c3e7c3eb0\#diff-8266b9d377a9df07645393a09139352c01636b7c84b6678586245e72c69dfe45L30-L82](https://github.com/openshift/kubernetes-autoscaler/commit/573eacd153c3e5b45bc18879a3c9b01c3e7c3eb0/#diff-8266b9d377a9df07645393a09139352c01636b7c84b6678586245e72c69dfe45L30-L82) was resolved during the rebase in a way that breaks CAPI support by removing the use of the getNodeGroupMinSizeAnnotationKey functions, there's no means in current state of the autoscaler to work with CAPI and cluster.x-k8s.io. This fixes it and aligns with upstream.