### PR TITLE
Bug 1944065: Have VPA ignore phantom containers named "POD"

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -250,6 +250,10 @@ func (feeder *clusterStateFeeder) InitFromHistoryProvider(historyProvider histor
 						ContainerUsageSample: sample,
 						Container:            containerID,
 					}); err != nil {
+					// Ignore missing "POD" containers returned by prometheus adapter
+					if _, isKeyError := err.(model.KeyError); isKeyError && containerName == "POD" {
+						continue
+					}
 					klog.Warningf("Error adding metric sample for container %v: %v", containerID, err)
 				}
 			}
@@ -449,7 +453,8 @@ func (feeder *clusterStateFeeder) LoadRealTimeMetrics() {
 		for _, sample := range newContainerUsageSamplesWithKey(containerMetrics) {
 			if err := feeder.clusterState.AddSample(sample); err != nil {
 				// Not all pod states are tracked in memory saver mode
-				if _, isKeyError := err.(model.KeyError); isKeyError && feeder.memorySaveMode {
+				// Also ignore missing containers named "POD" which prometheus adapter returns
+				if _, isKeyError := err.(model.KeyError); isKeyError && (feeder.memorySaveMode || sample.Container.ContainerName == "POD") {
 					continue
 				}
 				klog.Warningf("Error adding metric sample for container %v: %v", sample.Container, err)


### PR DESCRIPTION
Since prometheus adapter returns metrics for a phantom container named "POD" for every pod which has an init container, the VPA recommender should ignore the missing metrics for any such "POD" container.

#### Which component this PR applies to?

vertical-pod-autoscaler