### PR TITLE
Bug 2001027: update clusterapi nodegroups processor

### DIFF
--- a/cluster-autoscaler/processors/nodegroupset/clusterapi_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/clusterapi_nodegroups.go
@@ -25,7 +25,11 @@ import (
 // even if they have different infrastructure provider-specific labels.
 func CreateClusterAPINodeInfoComparator(extraIgnoredLabels []string) NodeInfoComparator {
 	capiIgnoredLabels := map[string]bool{
-		"topology.ebs.csi.aws.com/zone": true, // this is a label used by the AWS EBS CSI driver as a target for Persistent Volume Node Affinity
+		"topology.ebs.csi.aws.com/zone":                 true, // this is a label used by the AWS EBS CSI driver as a target for Persistent Volume Node Affinity
+		"topology.diskplugin.csi.alibabacloud.com/zone": true, // this is a label used by the Alibaba Cloud CSI driver as a target for Persistent Volume Node Affinity
+		"ibm-cloud.kubernetes.io/worker-id":             true, // this is a label used by the IBM Cloud Cloud Controler Manager
+		"vpc-block-csi-driver-labels":                   true, // this is a label used by the IBM Cloud CSI driver as a target for Persisten Volume Node Affinity
+
 	}
 
 	for k, v := range BasicIgnoredLabels {

--- a/cluster-autoscaler/processors/nodegroupset/clusterapi_nodegroups_test.go
+++ b/cluster-autoscaler/processors/nodegroupset/clusterapi_nodegroups_test.go
@@ -50,6 +50,27 @@ func TestIsClusterAPINodeInfoSimilar(t *testing.T) {
 			removeOneLabel: false,
 		},
 		{
+			description:    "topology.diskplugin.csi.alibabacloud.com/zone different values",
+			label:          "topology.diskplugin.csi.alibabacloud.com/zone",
+			value1:         "foo",
+			value2:         "bar",
+			removeOneLabel: false,
+		},
+		{
+			description:    "ibm-cloud.kubernetes.io/worker-id different values",
+			label:          "ibm-cloud.kubernetes.io/worker-id",
+			value1:         "foo",
+			value2:         "bar",
+			removeOneLabel: false,
+		},
+		{
+			description:    "vpc-block-csi-driver-labels different values",
+			label:          "vpc-block-csi-driver-labels",
+			value1:         "foo",
+			value2:         "bar",
+			removeOneLabel: false,
+		},
+		{
 			description:    "topology.ebs.csi.aws.com/zone one node labeled",
 			label:          "topology.ebs.csi.aws.com/zone",
 			value1:         "foo",


### PR DESCRIPTION
this change adds labels that are used on Alibaba Cloud and IBM Cloud for
CSI and CCM.
