### PR TITLE
OCPBUGS-2546: UPSTREAM: <carry>: switched policy for PodDisruptionBudget from v1beta1 to v1 in time for 1.25

### DIFF
--- a/cluster-autoscaler/core/scale_down.go
+++ b/cluster-autoscaler/core/scale_down.go
@@ -42,7 +42,8 @@ import (
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 
 	apiv1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	kube_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -1266,7 +1267,7 @@ func evictPod(podToEvict *apiv1.Pod, isDaemonSetPod bool, client kube_client.Int
 	var lastError error
 	for first := true; first || time.Now().Before(retryUntil); time.Sleep(waitBetweenRetries) {
 		first = false
-		eviction := &policyv1.Eviction{
+		eviction := &policyv1beta1.Eviction{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: podToEvict.Namespace,
 				Name:      podToEvict.Name,

--- a/cluster-autoscaler/core/scale_down_test.go
+++ b/cluster-autoscaler/core/scale_down_test.go
@@ -29,7 +29,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	apiv1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1beta1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -749,7 +749,7 @@ func TestDeleteNode(t *testing.T) {
 					if createAction == nil {
 						return false, nil, nil
 					}
-					eviction := createAction.GetObject().(*policyv1.Eviction)
+					eviction := createAction.GetObject().(*policyv1beta1.Eviction)
 					if eviction == nil {
 						return false, nil, nil
 					}
@@ -809,7 +809,7 @@ func TestDrainNode(t *testing.T) {
 		if createAction == nil {
 			return false, nil, nil
 		}
-		eviction := createAction.GetObject().(*policyv1.Eviction)
+		eviction := createAction.GetObject().(*policyv1beta1.Eviction)
 		if eviction == nil {
 			return false, nil, nil
 		}
@@ -855,7 +855,7 @@ func TestDrainNodeWithRescheduled(t *testing.T) {
 		if createAction == nil {
 			return false, nil, nil
 		}
-		eviction := createAction.GetObject().(*policyv1.Eviction)
+		eviction := createAction.GetObject().(*policyv1beta1.Eviction)
 		if eviction == nil {
 			return false, nil, nil
 		}
@@ -896,7 +896,7 @@ func TestDrainNodeWithRetries(t *testing.T) {
 		if createAction == nil {
 			return false, nil, nil
 		}
-		eviction := createAction.GetObject().(*policyv1.Eviction)
+		eviction := createAction.GetObject().(*policyv1beta1.Eviction)
 		if eviction == nil {
 			return false, nil, nil
 		}
@@ -945,7 +945,7 @@ func TestDrainNodeDaemonSetEvictionFailure(t *testing.T) {
 		if createAction == nil {
 			return false, nil, nil
 		}
-		eviction := createAction.GetObject().(*policyv1.Eviction)
+		eviction := createAction.GetObject().(*policyv1beta1.Eviction)
 		if eviction == nil {
 			return false, nil, nil
 		}
@@ -987,7 +987,7 @@ func TestDrainNodeEvictionFailure(t *testing.T) {
 		if createAction == nil {
 			return false, nil, nil
 		}
-		eviction := createAction.GetObject().(*policyv1.Eviction)
+		eviction := createAction.GetObject().(*policyv1beta1.Eviction)
 		if eviction == nil {
 			return false, nil, nil
 		}
@@ -1313,7 +1313,7 @@ func TestDaemonSetEvictionForEmptyNodes(t *testing.T) {
 				if createAction == nil {
 					return false, nil, nil
 				}
-				eviction := createAction.GetObject().(*policyv1.Eviction)
+				eviction := createAction.GetObject().(*policyv1beta1.Eviction)
 				if eviction == nil {
 					return false, nil, nil
 				}

--- a/cluster-autoscaler/core/static_autoscaler_test.go
+++ b/cluster-autoscaler/core/static_autoscaler_test.go
@@ -39,7 +39,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/fake"
 	v1appslister "k8s.io/client-go/listers/apps/v1"

--- a/cluster-autoscaler/simulator/cluster.go
+++ b/cluster-autoscaler/simulator/cluster.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/tpu"
 
 	apiv1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 

--- a/cluster-autoscaler/simulator/cluster_test.go
+++ b/cluster-autoscaler/simulator/cluster_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"

--- a/cluster-autoscaler/simulator/drain.go
+++ b/cluster-autoscaler/simulator/drain.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"

--- a/cluster-autoscaler/simulator/drain_test.go
+++ b/cluster-autoscaler/simulator/drain_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/drain"

--- a/cluster-autoscaler/utils/drain/drain.go
+++ b/cluster-autoscaler/utils/drain/drain.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/cluster-autoscaler/utils/drain/drain_test.go
+++ b/cluster-autoscaler/utils/drain/drain_test.go
@@ -23,7 +23,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	apiv1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	. "k8s.io/autoscaler/cluster-autoscaler/utils/test"

--- a/cluster-autoscaler/utils/kubernetes/listers.go
+++ b/cluster-autoscaler/utils/kubernetes/listers.go
@@ -22,14 +22,14 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	apiv1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	client "k8s.io/client-go/kubernetes"
 	v1appslister "k8s.io/client-go/listers/apps/v1"
 	v1batchlister "k8s.io/client-go/listers/batch/v1"
 	v1lister "k8s.io/client-go/listers/core/v1"
-	v1policylister "k8s.io/client-go/listers/policy/v1beta1"
+	v1policylister "k8s.io/client-go/listers/policy/v1"
 	"k8s.io/client-go/tools/cache"
 	podv1 "k8s.io/kubernetes/pkg/api/v1/pod"
 )
@@ -305,7 +305,7 @@ func (lister *PodDisruptionBudgetListerImpl) List() ([]*policyv1.PodDisruptionBu
 
 // NewPodDisruptionBudgetLister builds a pod disruption budget lister.
 func NewPodDisruptionBudgetLister(kubeClient client.Interface, stopchannel <-chan struct{}) PodDisruptionBudgetLister {
-	listWatcher := cache.NewListWatchFromClient(kubeClient.PolicyV1beta1().RESTClient(), "poddisruptionbudgets", apiv1.NamespaceAll, fields.Everything())
+	listWatcher := cache.NewListWatchFromClient(kubeClient.PolicyV1().RESTClient(), "poddisruptionbudgets", apiv1.NamespaceAll, fields.Everything())
 	store, reflector := cache.NewNamespaceKeyedIndexerAndReflector(listWatcher, &policyv1.PodDisruptionBudget{}, time.Hour)
 	pdbLister := v1policylister.NewPodDisruptionBudgetLister(store)
 	go reflector.Run(stopchannel)


### PR DESCRIPTION
this patch is being carried on the openshift release-4.10 so that we can ensure upgrades from 4.10 to 4.11 to 4.12 will work without issue.
