### PR TITLE
PODAUTO-91: Add joelsmith to OWNERS for approving of VPA-only PRs

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,7 @@ approvers:
 - JoelSpeed
 - elmiko
 - enxebre
+- joelsmith
 reviewers:
 - JoelSpeed
 - RadekManak


### PR DESCRIPTION
Since some VPA-only PRs touch files in the root directory, this will make the pod autoscaling team more independent