### PR TITLE
WIP: improve replica counting on openshift

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -46,6 +46,7 @@ const (
 	machinePoolProviderIDIndex = "machinePoolProviderIDIndex"
 	nodeProviderIDIndex        = "nodeProviderIDIndex"
 	defaultCAPIGroup           = "cluster.x-k8s.io"
+	openshiftMAPIGroup         = "machine.openshift.io"
 	// CAPIGroupEnvVar contains the environment variable name which allows overriding defaultCAPIGroup.
 	CAPIGroupEnvVar = "CAPI_GROUP"
 	// CAPIVersionEnvVar contains the environment variable name which allows overriding the Cluster API group version.


### PR DESCRIPTION
**DO NOT MERGE THIS YET**

This change adds logic to count the number of owned machines by each machineset when calculating the replica count to the core autoscaler. It is needed because the machine-api controllers do not include machines in deleting phase when updating their replica field. This causes a problem with the core autoscaler as the count of nodes will not match the resources from the cloud provider.

This can be removed when the machine-api controllers have been fully removed from openshift.
