### PR TITLE
OCPBUGS-27509: Fix unstructured taint parsing in Cluster API provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -347,6 +347,13 @@ func createTestConfigs(specs ...testSpec) []*testConfig {
 								"kind":       machineTemplateKind,
 								"name":       "TestMachineTemplate",
 							},
+							"taints": []interface{}{
+								map[string]interface{}{
+									"key":    "test",
+									"value":  "test",
+									"effect": "NoSchedule",
+								},
+							},
 						},
 					},
 				},
@@ -384,6 +391,13 @@ func createTestConfigs(specs ...testSpec) []*testConfig {
 									"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
 									"kind":       machineTemplateKind,
 									"name":       "TestMachineTemplate",
+								},
+								"taints": []interface{}{
+									map[string]interface{}{
+										"key":    "test",
+										"value":  "test",
+										"effect": "NoSchedule",
+									},
 								},
 							},
 						},

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -211,10 +211,10 @@ func (r unstructuredScalableResource) Taints() []apiv1.Taint {
 	}
 	if found {
 		for _, t := range newtaints {
-			if v, ok := t.(apiv1.Taint); ok {
-				taints = append(taints, v)
+			if t := unstructuredToTaint(t); t != nil {
+				taints = append(taints, *t)
 			} else {
-				klog.Warning("Unable to convert data to taint: %v", t)
+				klog.Warning("Unable to convert of type %T data to taint: %+v", t, t)
 				continue
 			}
 		}
@@ -233,6 +233,19 @@ func (r unstructuredScalableResource) Taints() []apiv1.Taint {
 	}
 
 	return taints
+}
+
+func unstructuredToTaint(unstructuredTaintInterface interface{}) *corev1.Taint {
+	unstructuredTaint := unstructuredTaintInterface.(map[string]interface{})
+	if unstructuredTaint == nil {
+		return nil
+	}
+
+	taint := &corev1.Taint{}
+	taint.Key = unstructuredTaint["key"].(string)
+	taint.Value = unstructuredTaint["value"].(string)
+	taint.Effect = corev1.TaintEffect(unstructuredTaint["effect"].(string))
+	return taint
 }
 
 // A node group can scale from zero if it can inform about the CPU and memory


### PR DESCRIPTION
When you use the unstructured utils to fetch a slice, it returns `[]interface{}`, which in fact, is a slice of `map[string]interface{}`. Using a type assertion on the unstructured entries in the slice doesn't work, and will never pass. To actually parse the taint, we have to do our own conversion manually. I've added a small helper that will achieve this and a test that will prevent us from regressing on this.

