### PR TITLE
PODAUTO-104: Add downstream pod autoscaling team member jkyros to VPA OWNERS

### DIFF
--- a/vertical-pod-autoscaler/OWNERS
+++ b/vertical-pod-autoscaler/OWNERS
@@ -3,3 +3,4 @@ approvers:
 - wangchen615
 - sjenning
 - rphillips
+- jkyros


### PR DESCRIPTION
Adds pod autoscaling team member @jkyros to VPA owners

It looks like we haven't touched the owners file since https://github.com/openshift/kubernetes-autoscaler/pull/250

From a "best practices" standpoint: 
- should I retitle this commit to match the commit from #250 (https://github.com/openshift/kubernetes-autoscaler/pull/250/commits/1a5c35650399a5fd8555c81a3b4c49345f007e6f) so it's obvious they could be squashed together next time we do a rebase, or is this okay?