### PR TITLE
OCPBUGS-28334: update snyk file

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,6 +1,19 @@
 # References:
+#
 # https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
 # https://docs.snyk.io/snyk-cli/commands/ignore
 exclude:
   global:
-    - vendor/**
+    - "vendor/**"
+    - "**/vendor/**"
+    # openshift does not build any provider aside from clusterapi into its binary
+    - "cluster-autoscaler/cloudprovider/alicloud/**"
+    - "cluster-autoscaler/cloudprovider/aws/**"
+    - "cluster-autoscaler/cloudprovider/azure/**"
+    - "cluster-autoscaler/cloudprovider/azure/**"
+    - "cluster-autoscaler/cloudprovider/cherryservers/**"
+    - "cluster-autoscaler/cloudprovider/civo/**"
+    - "cluster-autoscaler/cloudprovider/exoscale/**"
+    - "cluster-autoscaler/cloudprovider/volcengine/**"
+    # ensure we don't get aws artifacts in the unpacked sources
+    - "**/cluster-autoscaler/cloudprovider/aws/**"


### PR DESCRIPTION
This change expands the snyk configuration file to cover more vendor folders and the cloud provider folders which are causing issues. It is safe to exclude other cloud providers because only the clusterapi provider is compiled into the binary for release.
