### PR TITLE
[release-4.12] OCPBUGS-30911: Fix unstructured taint parsing in Cluster API provider

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -345,6 +345,10 @@ func createTestConfigs(specs ...testSpec) []*testConfig {
 									"value":  "test",
 									"effect": "NoSchedule",
 								},
+								map[string]interface{}{
+									"key":    "test-no-value",
+									"effect": "NoSchedule",
+								},
 							},
 						},
 					},
@@ -388,6 +392,10 @@ func createTestConfigs(specs ...testSpec) []*testConfig {
 									map[string]interface{}{
 										"key":    "test",
 										"value":  "test",
+										"effect": "NoSchedule",
+									},
+									map[string]interface{}{
+										"key":    "test-no-value",
 										"effect": "NoSchedule",
 									},
 								},

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -339,6 +339,13 @@ func createTestConfigs(specs ...testSpec) []*testConfig {
 								"kind":       machineTemplateKind,
 								"name":       "TestMachineTemplate",
 							},
+							"taints": []interface{}{
+								map[string]interface{}{
+									"key":    "test",
+									"value":  "test",
+									"effect": "NoSchedule",
+								},
+							},
 						},
 					},
 				},
@@ -376,6 +383,13 @@ func createTestConfigs(specs ...testSpec) []*testConfig {
 									"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
 									"kind":       machineTemplateKind,
 									"name":       "TestMachineTemplate",
+								},
+								"taints": []interface{}{
+									map[string]interface{}{
+										"key":    "test",
+										"value":  "test",
+										"effect": "NoSchedule",
+									},
 								},
 							},
 						},

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -203,7 +203,10 @@ func unstructuredToTaint(unstructuredTaintInterface interface{}) *corev1.Taint {
 
 	taint := &corev1.Taint{}
 	taint.Key = unstructuredTaint["key"].(string)
-	taint.Value = unstructuredTaint["value"].(string)
+	// value is optional and could be nil if not present
+	if unstructuredTaint["value"] != nil {
+		taint.Value = unstructuredTaint["value"].(string)
+	}
 	taint.Effect = corev1.TaintEffect(unstructuredTaint["effect"].(string))
 	return taint
 }

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -184,16 +184,28 @@ func (r unstructuredScalableResource) Taints() []apiv1.Taint {
 	if !found || err != nil {
 		return nil
 	}
-	ret := make([]apiv1.Taint, len(taints))
-	for i, t := range taints {
-		if v, ok := t.(apiv1.Taint); ok {
-			ret[i] = v
+	ret := make([]apiv1.Taint, 0)
+	for _, t := range taints {
+		if t := unstructuredToTaint(t); t != nil {
+			ret = append(ret, *t)
 		} else {
-			// if we cannot convert the interface to a Taint, return early with zero value
-			return nil
+			klog.Warning("Unable to convert of type %T data to taint: %+v", t, t)
 		}
 	}
 	return ret
+}
+
+func unstructuredToTaint(unstructuredTaintInterface interface{}) *corev1.Taint {
+	unstructuredTaint := unstructuredTaintInterface.(map[string]interface{})
+	if unstructuredTaint == nil {
+		return nil
+	}
+
+	taint := &corev1.Taint{}
+	taint.Key = unstructuredTaint["key"].(string)
+	taint.Value = unstructuredTaint["value"].(string)
+	taint.Effect = corev1.TaintEffect(unstructuredTaint["effect"].(string))
+	return taint
 }
 
 // A node group can scale from zero if it can inform about the CPU and memory

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
@@ -288,7 +288,10 @@ func TestSetSizeAndReplicas(t *testing.T) {
 func TestTaints(t *testing.T) {
 	initialReplicas := 1
 
-	expectedTaints := []v1.Taint{{Key: "test", Effect: v1.TaintEffectNoSchedule, Value: "test"}}
+	expectedTaints := []v1.Taint{
+		{Key: "test", Effect: v1.TaintEffectNoSchedule, Value: "test"},
+		{Key: "test-no-value", Effect: v1.TaintEffectNoSchedule},
+	}
 
 	test := func(t *testing.T, testConfig *testConfig) {
 		controller, stop := mustCreateTestController(t, testConfig)
@@ -325,7 +328,10 @@ func TestAnnotations(t *testing.T) {
 	memQuantity := resource.MustParse("1024")
 	gpuQuantity := resource.MustParse("1")
 	maxPodsQuantity := resource.MustParse("42")
-	expectedTaints := []v1.Taint{{Key: "test", Effect: v1.TaintEffectNoSchedule, Value: "test"}}
+	expectedTaints := []v1.Taint{
+		{Key: "test", Effect: v1.TaintEffectNoSchedule, Value: "test"},
+		{Key: "test-no-value", Effect: v1.TaintEffectNoSchedule},
+	}
 	annotations := map[string]string{
 		cpuKey:      cpuQuantity.String(),
 		memoryKey:   memQuantity.String(),

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
@@ -19,9 +19,12 @@ package clusterapi
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -282,11 +285,47 @@ func TestSetSizeAndReplicas(t *testing.T) {
 	})
 }
 
+func TestTaints(t *testing.T) {
+	initialReplicas := 1
+
+	expectedTaints := []v1.Taint{{Key: "test", Effect: v1.TaintEffectNoSchedule, Value: "test"}}
+
+	test := func(t *testing.T, testConfig *testConfig) {
+		controller, stop := mustCreateTestController(t, testConfig)
+		defer stop()
+
+		testResource := testConfig.machineSet
+		if testConfig.machineDeployment != nil {
+			testResource = testConfig.machineDeployment
+		}
+
+		sr, err := newUnstructuredScalableResource(controller, testResource)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		taints := sr.Taints()
+
+		if !reflect.DeepEqual(taints, expectedTaints) {
+			t.Errorf("expected %v, got: %v", expectedTaints, taints)
+		}
+	}
+
+	t.Run("MachineSet", func(t *testing.T) {
+		test(t, createMachineSetTestConfig(RandomString(6), RandomString(6), RandomString(6), initialReplicas, nil, nil))
+	})
+
+	t.Run("MachineDeployment", func(t *testing.T) {
+		test(t, createMachineDeploymentTestConfig(RandomString(6), RandomString(6), RandomString(6), initialReplicas, nil, nil))
+	})
+}
+
 func TestAnnotations(t *testing.T) {
 	cpuQuantity := resource.MustParse("2")
 	memQuantity := resource.MustParse("1024")
 	gpuQuantity := resource.MustParse("1")
 	maxPodsQuantity := resource.MustParse("42")
+	expectedTaints := []v1.Taint{{Key: "test", Effect: v1.TaintEffectNoSchedule, Value: "test"}}
 	annotations := map[string]string{
 		cpuKey:      cpuQuantity.String(),
 		memoryKey:   memQuantity.String(),
@@ -331,6 +370,9 @@ func TestAnnotations(t *testing.T) {
 		} else if maxPodsQuantity.Cmp(maxPods) != 0 {
 			t.Errorf("expected %v, got %v", maxPodsQuantity, maxPods)
 		}
+
+		taints := sr.Taints()
+		assert.Equal(t, expectedTaints, taints)
 	}
 
 	t.Run("MachineSet", func(t *testing.T) {


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/kubernetes-autoscaler/pull/289