### PR TITLE
OCPBUGS-31421: add check for taint.value == nil

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -353,6 +353,10 @@ func createTestConfigs(specs ...testSpec) []*testConfig {
 									"value":  "test",
 									"effect": "NoSchedule",
 								},
+								map[string]interface{}{
+									"key":    "test-no-value",
+									"effect": "NoSchedule",
+								},
 							},
 						},
 					},
@@ -396,6 +400,10 @@ func createTestConfigs(specs ...testSpec) []*testConfig {
 									map[string]interface{}{
 										"key":    "test",
 										"value":  "test",
+										"effect": "NoSchedule",
+									},
+									map[string]interface{}{
+										"key":    "test-no-value",
 										"effect": "NoSchedule",
 									},
 								},

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -243,7 +243,10 @@ func unstructuredToTaint(unstructuredTaintInterface interface{}) *corev1.Taint {
 
 	taint := &corev1.Taint{}
 	taint.Key = unstructuredTaint["key"].(string)
-	taint.Value = unstructuredTaint["value"].(string)
+	// value is optional and could be nil if not present
+	if unstructuredTaint["value"] != nil {
+		taint.Value = unstructuredTaint["value"].(string)
+	}
 	taint.Effect = corev1.TaintEffect(unstructuredTaint["effect"].(string))
 	return taint
 }

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
@@ -226,8 +226,16 @@ func TestReplicas(t *testing.T) {
 func TestTaints(t *testing.T) {
 	initialReplicas := 1
 
-	expectedTaints := []v1.Taint{{Key: "test", Effect: v1.TaintEffectNoSchedule, Value: "test"}}
-	expectedTaintsWithAnnotations := []v1.Taint{{Key: "test", Effect: v1.TaintEffectNoSchedule, Value: "test"}, {Key: "key1", Effect: v1.TaintEffectNoSchedule, Value: "value1"}, {Key: "key2", Effect: v1.TaintEffectNoExecute, Value: "value2"}}
+	expectedTaints := []v1.Taint{
+		{Key: "test", Effect: v1.TaintEffectNoSchedule, Value: "test"},
+		{Key: "test-no-value", Effect: v1.TaintEffectNoSchedule},
+	}
+	expectedTaintsWithAnnotations := []v1.Taint{
+		{Key: "test", Effect: v1.TaintEffectNoSchedule, Value: "test"},
+		{Key: "test-no-value", Effect: v1.TaintEffectNoSchedule},
+		{Key: "key1", Effect: v1.TaintEffectNoSchedule, Value: "value1"},
+		{Key: "key2", Effect: v1.TaintEffectNoExecute, Value: "value2"},
+	}
 	taintAnnotation := "key1=value1:NoSchedule,key2=value2:NoExecute"
 
 	test := func(t *testing.T, testConfig *testConfig) {
@@ -350,8 +358,14 @@ func TestAnnotations(t *testing.T) {
 	gpuQuantity := resource.MustParse("1")
 	maxPodsQuantity := resource.MustParse("42")
 
-	// Note, the first taint comes from the spec of the machine template, the rest from the annotations.
-	expectedTaints := []v1.Taint{{Key: "test", Effect: v1.TaintEffectNoSchedule, Value: "test"}, {Key: "key1", Effect: v1.TaintEffectNoSchedule, Value: "value1"}, {Key: "key2", Effect: v1.TaintEffectNoExecute, Value: "value2"}}
+	// Note, the first two taints comes from the spec of the machine template, the rest from the annotations.
+	expectedTaints := []v1.Taint{
+		{Key: "test", Effect: v1.TaintEffectNoSchedule, Value: "test"},
+		{Key: "test-no-value", Effect: v1.TaintEffectNoSchedule},
+		{Key: "key1", Effect: v1.TaintEffectNoSchedule, Value: "value1"},
+		{Key: "key2", Effect: v1.TaintEffectNoExecute, Value: "value2"},
+	}
+
 	annotations := map[string]string{
 		cpuKey:          cpuQuantity.String(),
 		memoryKey:       memQuantity.String(),


### PR DESCRIPTION
This change adds an extra check to ensure that the `value` field is not nil.
