### PR TITLE
[release-4.13] OCPBUGS-31702:  add check for taint.value == nil

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -345,6 +345,10 @@ func createTestConfigs(specs ...testSpec) []*testConfig {
 									"value":  "test",
 									"effect": "NoSchedule",
 								},
+								map[string]interface{}{
+									"key":    "test-no-value",
+									"effect": "NoSchedule",
+								},
 							},
 						},
 					},
@@ -388,6 +392,10 @@ func createTestConfigs(specs ...testSpec) []*testConfig {
 									map[string]interface{}{
 										"key":    "test",
 										"value":  "test",
+										"effect": "NoSchedule",
+									},
+									map[string]interface{}{
+										"key":    "test-no-value",
 										"effect": "NoSchedule",
 									},
 								},

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -203,7 +203,10 @@ func unstructuredToTaint(unstructuredTaintInterface interface{}) *corev1.Taint {
 
 	taint := &corev1.Taint{}
 	taint.Key = unstructuredTaint["key"].(string)
-	taint.Value = unstructuredTaint["value"].(string)
+	// value is optional and could be nil if not present
+	if unstructuredTaint["value"] != nil {
+		taint.Value = unstructuredTaint["value"].(string)
+	}
 	taint.Effect = corev1.TaintEffect(unstructuredTaint["effect"].(string))
 	return taint
 }

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
@@ -288,7 +288,10 @@ func TestSetSizeAndReplicas(t *testing.T) {
 func TestTaints(t *testing.T) {
 	initialReplicas := 1
 
-	expectedTaints := []v1.Taint{{Key: "test", Effect: v1.TaintEffectNoSchedule, Value: "test"}}
+	expectedTaints := []v1.Taint{
+		{Key: "test", Effect: v1.TaintEffectNoSchedule, Value: "test"},
+		{Key: "test-no-value", Effect: v1.TaintEffectNoSchedule},
+	}
 
 	test := func(t *testing.T, testConfig *testConfig) {
 		controller, stop := mustCreateTestController(t, testConfig)
@@ -325,7 +328,11 @@ func TestAnnotations(t *testing.T) {
 	memQuantity := resource.MustParse("1024")
 	gpuQuantity := resource.MustParse("1")
 	maxPodsQuantity := resource.MustParse("42")
-	expectedTaints := []v1.Taint{{Key: "test", Effect: v1.TaintEffectNoSchedule, Value: "test"}}
+	expectedTaints := []v1.Taint{
+		{Key: "test", Effect: v1.TaintEffectNoSchedule, Value: "test"},
+		{Key: "test-no-value", Effect: v1.TaintEffectNoSchedule},
+	}
+
 	annotations := map[string]string{
 		cpuKey:      cpuQuantity.String(),
 		memoryKey:   memQuantity.String(),


### PR DESCRIPTION
This change adds an extra check to ensure that the `value` field is not nil.
