### PR TITLE
WIP: adding a metric to track the NodeGroups interface function

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider.go
@@ -18,6 +18,7 @@ package clusterapi
 
 import (
 	"reflect"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -32,6 +33,7 @@ import (
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 )
@@ -59,6 +61,15 @@ func (p *provider) GetResourceLimiter() (*cloudprovider.ResourceLimiter, error) 
 
 func (p *provider) NodeGroups() []cloudprovider.NodeGroup {
 	var result []cloudprovider.NodeGroup
+
+	start := time.Now()
+	defer func() {
+		stop := time.Now()
+		elapsed := stop.Sub(start)
+		klog.V(4).Infof("NodeGroups duration: %f seconds", elapsed.Seconds())
+		metrics.RegisterProviderNodeGroupsDuration(elapsed.Seconds())
+	}()
+
 	nodegroups, err := p.controller.nodeGroups()
 	if err != nil {
 		klog.Errorf("error getting node groups: %v", err)

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -398,6 +398,14 @@ var (
 		},
 		[]string{"type"},
 	)
+
+	providerNodeGroupsDuration = k8smetrics.NewGauge(
+		&k8smetrics.GaugeOpts{
+			Namespace: caNamespace,
+			Name:      "provider_node_groups_duration",
+			Help:      "The duration of the NodeGroups call in seconds.",
+		},
+	)
 )
 
 // RegisterAll registers all metrics.
@@ -433,6 +441,7 @@ func RegisterAll(emitPerNodeGroupMetrics bool) {
 	legacyregistry.MustRegister(nodeGroupDeletionCount)
 	legacyregistry.MustRegister(pendingNodeDeletions)
 	legacyregistry.MustRegister(nodeTaintsCount)
+	legacyregistry.MustRegister(providerNodeGroupsDuration)
 
 	if emitPerNodeGroupMetrics {
 		legacyregistry.MustRegister(nodesGroupMinNodes)
@@ -659,4 +668,9 @@ func ObservePendingNodeDeletions(value int) {
 // ObserveNodeTaintsCount records the node taints count of given type.
 func ObserveNodeTaintsCount(taintType string, count float64) {
 	nodeTaintsCount.WithLabelValues(taintType).Set(count)
+}
+
+// RegisterProviderNodeGroupsDuration records the duration of a single NodeGroups provider interface call.
+func RegisterProviderNodeGroupsDuration(duration float64) {
+	providerNodeGroupsDuration.Set(duration)
 }


### PR DESCRIPTION
this is a test to add a metric for help understand performance issues with the `NodeGroups` call.

the metric created by this _should_ be `cluster_autoscaler_provider_node_groups_duration`