### PR TITLE
PODAUTO-199: Upstream rebase to VPA 1.1.2

### DIFF
--- a/vertical-pod-autoscaler/common/version.go
+++ b/vertical-pod-autoscaler/common/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package common
 
 // VerticalPodAutoscalerVersion is the version of VPA.
-const VerticalPodAutoscalerVersion = "1.1.0"
+const VerticalPodAutoscalerVersion = "1.1.1"

--- a/vertical-pod-autoscaler/common/version.go
+++ b/vertical-pod-autoscaler/common/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package common
 
 // VerticalPodAutoscalerVersion is the version of VPA.
-const VerticalPodAutoscalerVersion = "1.1.1"
+const VerticalPodAutoscalerVersion = "1.1.2"

--- a/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
         - name: admission-controller
-          image: registry.k8s.io/autoscaling/vpa-admission-controller:1.1.0
+          image: registry.k8s.io/autoscaling/vpa-admission-controller:1.1.1
           imagePullPolicy: Always
           env:
             - name: NAMESPACE

--- a/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
         - name: admission-controller
-          image: registry.k8s.io/autoscaling/vpa-admission-controller:1.1.1
+          image: registry.k8s.io/autoscaling/vpa-admission-controller:1.1.2
           imagePullPolicy: Always
           env:
             - name: NAMESPACE

--- a/vertical-pod-autoscaler/deploy/recommender-deployment-high.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-high.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.1.0
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.1.1
         imagePullPolicy: Always
         args:
           - --recommender-name=performance

--- a/vertical-pod-autoscaler/deploy/recommender-deployment-high.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-high.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.1.1
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.1.2
         imagePullPolicy: Always
         args:
           - --recommender-name=performance

--- a/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.1.1
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.1.2
         imagePullPolicy: Always
         args:
           - --recommender-name=frugal

--- a/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.1.0
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.1.1
         imagePullPolicy: Always
         args:
           - --recommender-name=frugal

--- a/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.1.1
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.1.2
         imagePullPolicy: Always
         resources:
           limits:

--- a/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:1.1.0
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.1.1
         imagePullPolicy: Always
         resources:
           limits:

--- a/vertical-pod-autoscaler/deploy/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/updater-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
         - name: updater
-          image: registry.k8s.io/autoscaling/vpa-updater:1.1.0
+          image: registry.k8s.io/autoscaling/vpa-updater:1.1.1
           imagePullPolicy: Always
           env:
             - name: NAMESPACE

--- a/vertical-pod-autoscaler/deploy/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/updater-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
         - name: updater
-          image: registry.k8s.io/autoscaling/vpa-updater:1.1.1
+          image: registry.k8s.io/autoscaling/vpa-updater:1.1.2
           imagePullPolicy: Always
           env:
             - name: NAMESPACE

--- a/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
@@ -32,7 +32,7 @@ if [ $# -eq 0 ]; then
 fi
 
 DEFAULT_REGISTRY="registry.k8s.io/autoscaling"
-DEFAULT_TAG="1.1.1"
+DEFAULT_TAG="1.1.2"
 
 REGISTRY_TO_APPLY=${REGISTRY-$DEFAULT_REGISTRY}
 TAG_TO_APPLY=${TAG-$DEFAULT_TAG}

--- a/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
@@ -32,7 +32,7 @@ if [ $# -eq 0 ]; then
 fi
 
 DEFAULT_REGISTRY="registry.k8s.io/autoscaling"
-DEFAULT_TAG="1.1.0"
+DEFAULT_TAG="1.1.1"
 
 REGISTRY_TO_APPLY=${REGISTRY-$DEFAULT_REGISTRY}
 TAG_TO_APPLY=${TAG-$DEFAULT_TAG}

--- a/vertical-pod-autoscaler/pkg/updater/priority/scaling_direction_pod_eviction_admission.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/scaling_direction_pod_eviction_admission.go
@@ -108,6 +108,10 @@ func (s *scalingDirectionPodEvictionAdmission) LoopInit(_ []*apiv1.Pod, vpaContr
 	s.EvictionRequirements = make(map[*apiv1.Pod][]*vpa_types.EvictionRequirement)
 	for vpa, pods := range vpaControlledPods {
 		for _, pod := range pods {
+			// When UpdatePolicy is not specified, the default policy will be followed, and the EvictionRequirements field will be nil
+			if vpa.Spec.UpdatePolicy == nil {
+				continue
+			}
 			s.EvictionRequirements[pod] = vpa.Spec.UpdatePolicy.EvictionRequirements
 		}
 	}

--- a/vertical-pod-autoscaler/pkg/updater/priority/scaling_direction_pod_eviction_admission_test.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/scaling_direction_pod_eviction_admission_test.go
@@ -55,6 +55,21 @@ func TestLoopInit(t *testing.T) {
 		Get()
 	vpaToPodMap := map[*v1.VerticalPodAutoscaler][]*corev1.Pod{testVPA: {pod, pod2}}
 
+	t.Run("it should not require UpdateMode and EvictionRequirements.", func(t *testing.T) {
+		sdpea := NewScalingDirectionPodEvictionAdmission()
+		sdpea.LoopInit(nil, vpaToPodMap)
+
+		newTestVPA := test.VerticalPodAutoscaler().
+			WithName("test-vpa").
+			WithContainer(container1Name).
+			Get()
+
+		newVpaToPodMap := map[*v1.VerticalPodAutoscaler][]*corev1.Pod{newTestVPA: {pod, pod2}}
+
+		sdpea.LoopInit(nil, newVpaToPodMap)
+		assert.Len(t, sdpea.(*scalingDirectionPodEvictionAdmission).EvictionRequirements, 0)
+	})
+
 	t.Run("it should store EvictionRequirements from VPA in a map per Pod", func(t *testing.T) {
 		sdpea := NewScalingDirectionPodEvictionAdmission()
 		sdpea.LoopInit(nil, vpaToPodMap)


### PR DESCRIPTION
These steps were followed in these commits:
```
git merge-base kubernetes/master vertical-pod-autoscaler-1.1.2
git log --oneline 151923f..vertical-pod-autoscaler-1.1.2  | grep -v Merge.pull
```
The first one is to find the common ancestor, and the next one to show what has changed from that point to the 1.1.2 release (ignoring merge commits)

Then we cherry-pick VPA related commits:
```
for commit in 7d2bd3037 0bc73b3fb 991308df3 cd673e325 b4ce36e40 3609234c5; do
  git cherry-pick $commit || break
  git commit --amend -m "UPSTREAM: <drop>: $(git show --format=format:%s -s $commit)"
done
```