### PR TITLE
PODAUTO-202: Update VPA ocp/builder Dockerfile images to openshift/release images

### DIFF
--- a/vertical-pod-autoscaler/Dockerfile.openshift
+++ b/vertical-pod-autoscaler/Dockerfile.openshift
@@ -1,11 +1,11 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.15 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17 AS builder
 WORKDIR /go/src/k8s.io/autoscaler/vertical-pod-autoscaler
 COPY . .
 RUN go build ./pkg/admission-controller
 RUN go build ./pkg/updater
 RUN go build ./pkg/recommender
 
-FROM registry.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 COPY --from=builder \
     /go/src/k8s.io/autoscaler/vertical-pod-autoscaler/admission-controller \
     /go/src/k8s.io/autoscaler/vertical-pod-autoscaler/updater \

--- a/vertical-pod-autoscaler/Dockerfile.rhel
+++ b/vertical-pod-autoscaler/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17 AS builder
 WORKDIR /go/src/k8s.io/autoscaler/vertical-pod-autoscaler
 COPY . .
 RUN go build ./pkg/admission-controller


### PR DESCRIPTION
Change updates VPA images to be consistent with other PodAutoscaling images.