### PR TITLE
WIP: Updates clusterapi cloudprovider DecreaseTargetSize

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -197,7 +197,7 @@ func (ng *nodegroup) DecreaseTargetSize(delta int) error {
 	}
 
 	if size+delta < len(nodes) {
-		klog.V(4).Infof("%s: DecreaseTargetSize: attempt to delete existing nodes targetSize: %d, delta: %d, existingNodes: %d, skipping", ng.scalableResource.Name(), size, delta, len(nodes))
+		klog.V(4).Infof("%s: DecreaseTargetSize: attempt to delete existing nodes, current replicas: %d, delta: %d, existing nodes: %d, skipping", ng.scalableResource.Name(), size, delta, len(nodes))
 		return nil
 	}
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -181,6 +181,7 @@ func (ng *nodegroup) DeleteNodes(nodes []*corev1.Node) error {
 // nodegroup will not delete the existing nodes when there is an option
 // to just decrease the target. Implementation required.
 func (ng *nodegroup) DecreaseTargetSize(delta int) error {
+	klog.V(4).Infof("%s: DecreaseTargetSize called", ng.scalableResource.Name())
 	if delta >= 0 {
 		return fmt.Errorf("size decrease must be negative")
 	}
@@ -196,10 +197,11 @@ func (ng *nodegroup) DecreaseTargetSize(delta int) error {
 	}
 
 	if size+delta < len(nodes) {
-		return fmt.Errorf("attempt to delete existing nodes targetSize:%d delta:%d existingNodes: %d",
-			size, delta, len(nodes))
+		klog.V(4).Infof("%s: DecreaseTargetSize: attempt to delete existing nodes targetSize: %d, delta: %d, existingNodes: %d, skipping", ng.scalableResource.Name(), size, delta, len(nodes))
+		return nil
 	}
 
+	klog.V(4).Infof("%s: DecreaseTargetSize: scaling down: targetSize: %d, delta: %d, existingNodes: %d", ng.scalableResource.Name(), size, delta, len(nodes))
 	return ng.scalableResource.SetSize(size + delta)
 }
 


### PR DESCRIPTION
This change updates DecreaseTargetSize to not return an error if the requested delta would lead to existing nodes being deleted. Instead it logs the error, and returns.

This is to try and debug CA issues where we end up in a state where we attempt to reduce the target size, but have more nodes than replicas.

It also adds logging around when DecreaseTargetSize succesfully decreases the target size.

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
