### PR TITLE
PODAUTO-266: Update VPA dockerfile to 4.19

### DIFF
--- a/vertical-pod-autoscaler/Dockerfile.openshift
+++ b/vertical-pod-autoscaler/Dockerfile.openshift
@@ -1,11 +1,11 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.18 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.19 AS builder
 WORKDIR /go/src/k8s.io/autoscaler/vertical-pod-autoscaler
 COPY . .
 RUN go build ./pkg/admission-controller
 RUN go build ./pkg/updater
 RUN go build ./pkg/recommender
 
-FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 COPY --from=builder \
     /go/src/k8s.io/autoscaler/vertical-pod-autoscaler/admission-controller \
     /go/src/k8s.io/autoscaler/vertical-pod-autoscaler/updater \


### PR DESCRIPTION
Just updates the `vertical-pod-autoscaler/Dockerfile.openshift` file to `go1.23/ocp4.19` that is used by CI. 