### PR TITLE
OCPCLOUD-2500: Update to recognize both upstream and openshift ScaleFromZero annotations

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -1328,12 +1328,124 @@ func TestNodeGroupTemplateNodeInfo(t *testing.T) {
 			},
 		},
 		{
-			name: "When the NodeGroup can scale from zero",
+			name: "When the NodeGroup can scale from zero with upstream annotations",
 			nodeGroupAnnotations: map[string]string{
 				memoryKey:   "2048",
 				cpuKey:      "2",
 				gpuTypeKey:  gpuapis.ResourceNvidiaGPU,
 				gpuCountKey: "1",
+			},
+			config: testCaseConfig{
+				expectedErr: nil,
+				nodeLabels: map[string]string{
+					"kubernetes.io/os":   "linux",
+					"kubernetes.io/arch": "amd64",
+				},
+				expectedCapacity: map[corev1.ResourceName]int64{
+					corev1.ResourceCPU:        2,
+					corev1.ResourceMemory:     2048,
+					corev1.ResourcePods:       110,
+					gpuapis.ResourceNvidiaGPU: 1,
+				},
+				expectedNodeLabels: map[string]string{
+					"kubernetes.io/os":       "linux",
+					"kubernetes.io/arch":     "amd64",
+					"kubernetes.io/hostname": "random value",
+				},
+			},
+		},
+		{
+			name: "When the NodeGroup can scale from zero and the nodegroup adds labels to the Node with upstream annotations",
+			nodeGroupAnnotations: map[string]string{
+				memoryKey: "2048",
+				cpuKey:    "2",
+			},
+			config: testCaseConfig{
+				expectedErr: nil,
+				nodegroupLabels: map[string]string{
+					"nodeGroupLabel": "value",
+					"anotherLabel":   "anotherValue",
+				},
+				expectedCapacity: map[corev1.ResourceName]int64{
+					corev1.ResourceCPU:    2,
+					corev1.ResourceMemory: 2048,
+					corev1.ResourcePods:   110,
+				},
+				expectedNodeLabels: map[string]string{
+					"kubernetes.io/os":       "linux",
+					"kubernetes.io/arch":     "amd64",
+					"kubernetes.io/hostname": "random value",
+					"nodeGroupLabel":         "value",
+					"anotherLabel":           "anotherValue",
+				},
+			},
+		},
+		{
+			name: "When the NodeGroup can scale from zero, the label capacity annotations merge with the pre-built node labels and take precedence if the same key is defined in both with upstream annotations",
+			nodeGroupAnnotations: map[string]string{
+				memoryKey:   "2048",
+				cpuKey:      "2",
+				gpuTypeKey:  gpuapis.ResourceNvidiaGPU,
+				gpuCountKey: "1",
+				labelsKey:   "kubernetes.io/arch=arm64,my-custom-label=custom-value",
+			},
+			config: testCaseConfig{
+				expectedErr: nil,
+				nodegroupLabels: map[string]string{
+					"nodeGroupLabel":  "value",
+					"anotherLabel":    "anotherValue",
+					"my-custom-label": "not-what-i-want",
+				},
+				expectedCapacity: map[corev1.ResourceName]int64{
+					corev1.ResourceCPU:        2,
+					corev1.ResourceMemory:     2048,
+					corev1.ResourcePods:       110,
+					gpuapis.ResourceNvidiaGPU: 1,
+				},
+				expectedNodeLabels: map[string]string{
+					"kubernetes.io/hostname": "random value",
+					"kubernetes.io/os":       "linux",
+					"kubernetes.io/arch":     "arm64",
+					"nodeGroupLabel":         "value",
+					"anotherLabel":           "anotherValue",
+					"my-custom-label":        "custom-value",
+				},
+			},
+		},
+		{
+			name: "When the NodeGroup can scale from zero and the Node still exists, it includes the known node labels with upstream annotations",
+			nodeGroupAnnotations: map[string]string{
+				memoryKey: "2048",
+				cpuKey:    "2",
+			},
+			config: testCaseConfig{
+				includeNodes: true,
+				expectedErr:  nil,
+				nodeLabels: map[string]string{
+					"kubernetes.io/os":                 "windows",
+					"kubernetes.io/arch":               "arm64",
+					"node.kubernetes.io/instance-type": "instance1",
+				},
+				expectedCapacity: map[corev1.ResourceName]int64{
+					corev1.ResourceCPU:    2,
+					corev1.ResourceMemory: 2048,
+					corev1.ResourcePods:   110,
+				},
+				expectedNodeLabels: map[string]string{
+					"kubernetes.io/hostname":           "random value",
+					"kubernetes.io/os":                 "windows",
+					"kubernetes.io/arch":               "arm64",
+					"node.kubernetes.io/instance-type": "instance1",
+				},
+			},
+		},
+		{
+			name: "When the NodeGroup can scale from zero with downstream annotations",
+			nodeGroupAnnotations: map[string]string{
+				deprecatedMemoryKey:   "2048",
+				deprecatedCpuKey:      "2",
+				gpuTypeKey:            gpuapis.ResourceNvidiaGPU,
+				deprecatedGpuCountKey: "1",
 			},
 			config: testCaseConfig{
 				expectedErr: nil,
@@ -1355,10 +1467,10 @@ func TestNodeGroupTemplateNodeInfo(t *testing.T) {
 			},
 		},
 		{
-			name: "When the NodeGroup can scale from zero and the nodegroup adds labels to the Node",
+			name: "When the NodeGroup can scale from zero and the nodegroup adds labels to the Node with downstream annotations",
 			nodeGroupAnnotations: map[string]string{
-				memoryKey: "2048",
-				cpuKey:    "2",
+				deprecatedMemoryKey: "2048",
+				deprecatedCpuKey:    "2",
 			},
 			config: testCaseConfig{
 				expectedErr: nil,
@@ -1381,13 +1493,13 @@ func TestNodeGroupTemplateNodeInfo(t *testing.T) {
 			},
 		},
 		{
-			name: "When the NodeGroup can scale from zero, the label capacity annotations merge with the pre-built node labels and take precedence if the same key is defined in both",
+			name: "When the NodeGroup can scale from zero, the label capacity annotations merge with the pre-built node labels and take precedence if the same key is defined in both with downstream annotations",
 			nodeGroupAnnotations: map[string]string{
-				memoryKey:   "2048",
-				cpuKey:      "2",
-				gpuTypeKey:  gpuapis.ResourceNvidiaGPU,
-				gpuCountKey: "1",
-				labelsKey:   "kubernetes.io/arch=arm64,my-custom-label=custom-value",
+				deprecatedMemoryKey:   "2048",
+				deprecatedCpuKey:      "2",
+				gpuTypeKey:            gpuapis.ResourceNvidiaGPU,
+				deprecatedGpuCountKey: "1",
+				labelsKey:             "kubernetes.io/arch=arm64,my-custom-label=custom-value",
 			},
 			config: testCaseConfig{
 				expectedErr: nil,
@@ -1413,10 +1525,10 @@ func TestNodeGroupTemplateNodeInfo(t *testing.T) {
 			},
 		},
 		{
-			name: "When the NodeGroup can scale from zero and the Node still exists, it includes the known node labels",
+			name: "When the NodeGroup can scale from zero and the Node still exists, it includes the known node labels with downstream annotations",
 			nodeGroupAnnotations: map[string]string{
-				memoryKey: "2048",
-				cpuKey:    "2",
+				deprecatedMemoryKey: "2048",
+				deprecatedCpuKey:    "2",
 			},
 			config: testCaseConfig{
 				includeNodes: true,

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/units"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -351,6 +350,7 @@ func TestSetSizeAndReplicas(t *testing.T) {
 	})
 }
 
+// This test now tests both the upstream and downstream annotation values while we support them both.
 func TestAnnotations(t *testing.T) {
 	cpuQuantity := resource.MustParse("2")
 	diskQuantity := resource.MustParse("100Gi")
@@ -376,11 +376,6 @@ func TestAnnotations(t *testing.T) {
 		labelsKey:       "key3=value3,key4=value4,key5=value5",
 	}
 
-	// convert the initial memory value from Mebibytes to bytes as this conversion happens internally
-	// when we use InstanceMemoryCapacity()
-	memVal, _ := memQuantity.AsInt64()
-	memQuantityAsBytes := resource.NewQuantity(memVal*units.MiB, resource.DecimalSI)
-
 	test := func(t *testing.T, testConfig *testConfig, testResource *unstructured.Unstructured) {
 		controller, stop := mustCreateTestController(t, testConfig)
 		defer stop()
@@ -398,7 +393,7 @@ func TestAnnotations(t *testing.T) {
 
 		if mem, err := sr.InstanceMemoryCapacityAnnotation(); err != nil {
 			t.Fatal(err)
-		} else if memQuantityAsBytes.Cmp(mem) != 0 {
+		} else if memQuantity.Cmp(mem) != 0 {
 			t.Errorf("expected %v, got %v", memQuantity, mem)
 		}
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils_test.go
@@ -457,23 +457,43 @@ func TestParseCPUCapacity(t *testing.T) {
 		expectedQuantity: zeroQuantity.DeepCopy(),
 		expectedError:    false,
 	}, {
-		description:      "bad quantity",
+		description:      "upstream bad quantity",
 		annotations:      map[string]string{cpuKey: "not-a-quantity"},
 		expectedQuantity: zeroQuantity.DeepCopy(),
 		expectedError:    true,
 	}, {
-		description:      "valid quantity with units",
+		description:      "upstream valid quantity with units",
 		annotations:      map[string]string{cpuKey: "123m"},
 		expectedError:    false,
 		expectedQuantity: resource.MustParse("123m"),
 	}, {
-		description:      "valid quantity without units",
+		description:      "upstream valid quantity without units",
 		annotations:      map[string]string{cpuKey: "1"},
 		expectedError:    false,
 		expectedQuantity: resource.MustParse("1"),
 	}, {
-		description:      "valid fractional quantity without units",
+		description:      "upstream valid fractional quantity without units",
 		annotations:      map[string]string{cpuKey: "0.1"},
+		expectedError:    false,
+		expectedQuantity: resource.MustParse("0.1"),
+	}, {
+		description:      "downstream bad quantity",
+		annotations:      map[string]string{deprecatedCpuKey: "not-a-quantity"},
+		expectedQuantity: zeroQuantity.DeepCopy(),
+		expectedError:    true,
+	}, {
+		description:      "downstream valid quantity with units",
+		annotations:      map[string]string{deprecatedCpuKey: "123m"},
+		expectedError:    false,
+		expectedQuantity: resource.MustParse("123m"),
+	}, {
+		description:      "downstream valid quantity without units",
+		annotations:      map[string]string{deprecatedCpuKey: "1"},
+		expectedError:    false,
+		expectedQuantity: resource.MustParse("1"),
+	}, {
+		description:      "downstream valid fractional quantity without units",
+		annotations:      map[string]string{deprecatedCpuKey: "0.1"},
 		expectedError:    false,
 		expectedQuantity: resource.MustParse("0.1"),
 	}} {
@@ -505,23 +525,43 @@ func TestParseMemoryCapacity(t *testing.T) {
 		expectedQuantity: zeroQuantity.DeepCopy(),
 		expectedError:    false,
 	}, {
-		description:      "bad quantity",
+		description:      "upstream bad quantity",
 		annotations:      map[string]string{memoryKey: "not-a-quantity"},
 		expectedQuantity: zeroQuantity.DeepCopy(),
 		expectedError:    true,
 	}, {
-		description:      "quantity as with no unit type",
+		description:      "upstream quantity as with no unit type",
 		annotations:      map[string]string{memoryKey: "1024"},
-		expectedQuantity: *resource.NewQuantity(1024*units.MiB, resource.DecimalSI),
+		expectedQuantity: resource.MustParse("1024"),
 		expectedError:    false,
 	}, {
-		description:      "quantity with unit type (Mi)",
+		description:      "upstream quantity with unit type (Mi)",
 		annotations:      map[string]string{memoryKey: "456Mi"},
+		expectedQuantity: resource.MustParse("456Mi"),
+		expectedError:    false,
+	}, {
+		description:      "upstream quantity with unit type (Gi)",
+		annotations:      map[string]string{memoryKey: "8Gi"},
+		expectedQuantity: resource.MustParse("8Gi"),
+		expectedError:    false,
+	}, {
+		description:      "downstream bad quantity",
+		annotations:      map[string]string{deprecatedMemoryKey: "not-a-quantity"},
 		expectedQuantity: zeroQuantity.DeepCopy(),
 		expectedError:    true,
 	}, {
-		description:      "quantity with unit type (Gi)",
-		annotations:      map[string]string{memoryKey: "8Gi"},
+		description:      "downstream quantity as with no unit type",
+		annotations:      map[string]string{deprecatedMemoryKey: "1024"},
+		expectedQuantity: *resource.NewQuantity(1024*units.MiB, resource.DecimalSI),
+		expectedError:    false,
+	}, {
+		description:      "downstream quantity with unit type (Mi)",
+		annotations:      map[string]string{deprecatedMemoryKey: "456Mi"},
+		expectedQuantity: zeroQuantity.DeepCopy(),
+		expectedError:    true,
+	}, {
+		description:      "downstream quantity with unit type (Gi)",
+		annotations:      map[string]string{deprecatedMemoryKey: "8Gi"},
 		expectedQuantity: zeroQuantity.DeepCopy(),
 		expectedError:    true,
 	}} {
@@ -553,18 +593,33 @@ func TestParseGPUCapacity(t *testing.T) {
 		expectedQuantity: zeroQuantity.DeepCopy(),
 		expectedError:    false,
 	}, {
-		description:      "bad quantity",
+		description:      "upstream bad quantity",
 		annotations:      map[string]string{gpuCountKey: "not-a-quantity"},
 		expectedQuantity: zeroQuantity.DeepCopy(),
 		expectedError:    true,
 	}, {
-		description:      "valid quantity",
+		description:      "upstream valid quantity",
 		annotations:      map[string]string{gpuCountKey: "13"},
 		expectedError:    false,
 		expectedQuantity: resource.MustParse("13"),
 	}, {
-		description:      "valid quantity, bad unit type",
+		description:      "upstream valid quantity, bad unit type",
 		annotations:      map[string]string{gpuCountKey: "13Mi"},
+		expectedQuantity: zeroQuantity.DeepCopy(),
+		expectedError:    true,
+	}, {
+		description:      "downstream bad quantity",
+		annotations:      map[string]string{deprecatedGpuCountKey: "not-a-quantity"},
+		expectedQuantity: zeroQuantity.DeepCopy(),
+		expectedError:    true,
+	}, {
+		description:      "downstream valid quantity",
+		annotations:      map[string]string{deprecatedGpuCountKey: "13"},
+		expectedError:    false,
+		expectedQuantity: resource.MustParse("13"),
+	}, {
+		description:      "downstream valid quantity, bad unit type",
+		annotations:      map[string]string{deprecatedGpuCountKey: "13Mi"},
 		expectedQuantity: zeroQuantity.DeepCopy(),
 		expectedError:    true,
 	}} {
@@ -596,18 +651,33 @@ func TestParseMaxPodsCapacity(t *testing.T) {
 		expectedQuantity: zeroQuantity.DeepCopy(),
 		expectedError:    false,
 	}, {
-		description:      "bad quantity",
+		description:      "upstream bad quantity",
 		annotations:      map[string]string{maxPodsKey: "not-a-quantity"},
 		expectedQuantity: zeroQuantity.DeepCopy(),
 		expectedError:    true,
 	}, {
-		description:      "valid quantity",
+		description:      "upstream valid quantity",
 		annotations:      map[string]string{maxPodsKey: "13"},
 		expectedError:    false,
 		expectedQuantity: resource.MustParse("13"),
 	}, {
-		description:      "valid quantity, bad unit type",
+		description:      "upstream valid quantity, bad unit type",
 		annotations:      map[string]string{maxPodsKey: "13Mi"},
+		expectedQuantity: zeroQuantity.DeepCopy(),
+		expectedError:    true,
+	}, {
+		description:      "downstream bad quantity",
+		annotations:      map[string]string{deprecatedMaxPodsKey: "not-a-quantity"},
+		expectedQuantity: zeroQuantity.DeepCopy(),
+		expectedError:    true,
+	}, {
+		description:      "downstream valid quantity",
+		annotations:      map[string]string{deprecatedMaxPodsKey: "13"},
+		expectedError:    false,
+		expectedQuantity: resource.MustParse("13"),
+	}, {
+		description:      "downstream valid quantity, bad unit type",
+		annotations:      map[string]string{deprecatedMaxPodsKey: "13Mi"},
 		expectedQuantity: zeroQuantity.DeepCopy(),
 		expectedError:    true,
 	}} {


### PR DESCRIPTION
#### What type of PR is this?

<!--
/kind feature
-->

#### What this PR does / why we need it:
Hello! This is a PR to update the autoscaler to recognize both the upstream and openshift ScaleFromZero annotations, while favouring the upstream annotations if they exist. Thanks!

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
