### PR TITLE
[release-4.17] OCPBUGS-48606: UPSTREAM: <carry>: 🐛(metrics) Initialize metrics for autoscaler errors, scale events, and pod evictions

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -18,8 +18,9 @@ package clusterapi
 
 import (
 	"fmt"
-	"k8s.io/klog/v2"
 	"math/rand"
+
+	"k8s.io/klog/v2"
 
 	"github.com/pkg/errors"
 

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -566,6 +566,9 @@ func buildAutoscaler(debuggingSnapshotter debuggingsnapshot.DebuggingSnapshotter
 	metrics.UpdateCPULimitsCores(autoscalingOptions.MinCoresTotal, autoscalingOptions.MaxCoresTotal)
 	metrics.UpdateMemoryLimitsBytes(autoscalingOptions.MinMemoryTotal, autoscalingOptions.MaxMemoryTotal)
 
+	// Initialize metrics.
+	metrics.InitMetrics()
+
 	// Create autoscaler.
 	autoscaler, err := core.NewAutoscaler(opts, informerFactory)
 	if err != nil {

--- a/cluster-autoscaler/metrics/metrics.go
+++ b/cluster-autoscaler/metrics/metrics.go
@@ -462,6 +462,28 @@ func RegisterAll(emitPerNodeGroupMetrics bool) {
 	}
 }
 
+// InitMetrics initializes all metrics
+func InitMetrics() {
+	for _, errorType := range []errors.AutoscalerErrorType{errors.CloudProviderError, errors.ApiCallError, errors.InternalError, errors.TransientError, errors.ConfigurationError, errors.NodeGroupDoesNotExistError, errors.UnexpectedScaleDownStateError} {
+		errorsCount.WithLabelValues(string(errorType)).Add(0)
+	}
+
+	for _, reason := range []FailedScaleUpReason{CloudProviderError, APIError, Timeout} {
+		scaleDownCount.WithLabelValues(string(reason)).Add(0)
+		failedScaleUpCount.WithLabelValues(string(reason)).Add(0)
+	}
+
+	for _, result := range []PodEvictionResult{PodEvictionSucceed, PodEvictionFailed} {
+		evictionsCount.WithLabelValues(string(result)).Add(0)
+	}
+
+	skippedScaleEventsCount.WithLabelValues(DirectionScaleDown, CpuResourceLimit).Add(0)
+	skippedScaleEventsCount.WithLabelValues(DirectionScaleDown, MemoryResourceLimit).Add(0)
+	skippedScaleEventsCount.WithLabelValues(DirectionScaleUp, CpuResourceLimit).Add(0)
+	skippedScaleEventsCount.WithLabelValues(DirectionScaleUp, MemoryResourceLimit).Add(0)
+
+}
+
 // UpdateDurationFromStart records the duration of the step identified by the
 // label using start time
 func UpdateDurationFromStart(label FunctionLabel, start time.Time) {


### PR DESCRIPTION
cherry-pick of https://github.com/openshift/kubernetes-autoscaler/pull/332