### PR TITLE
OCPBUGS-11115: refactor findScalableResourceProviderIDs

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -357,6 +357,11 @@ func machineKeyFromDeletingMachineProviderID(providerID normalizedProviderID) st
 	return strings.Replace(namespaceName, "_", "/", 1)
 }
 
+// createPendingMachineProviderID creates a providerID for a machine that is pending
+func createPendingMachineProviderID(namespace, name string) string {
+	return fmt.Sprintf("%s%s_%s", pendingMachinePrefix, namespace, name)
+}
+
 func isPendingMachineProviderID(providerID normalizedProviderID) bool {
 	return strings.HasPrefix(string(providerID), pendingMachinePrefix)
 }
@@ -377,6 +382,15 @@ func isFailedMachineProviderID(providerID normalizedProviderID) bool {
 func machineKeyFromFailedProviderID(providerID normalizedProviderID) string {
 	namespaceName := strings.TrimPrefix(string(providerID), failedMachinePrefix)
 	return strings.Replace(namespaceName, "_", "/", 1)
+}
+
+// nodeHasValidProviderID determines whether a node's providerID is the standard
+// providerID assigned by the cloud provider, or if it has
+// been modified by the CAS CAPI provider to indicate deleting, pending, or failed
+func nodeHasValidProviderID(providerID normalizedProviderID) bool {
+	return !isDeletingMachineProviderID(providerID) &&
+		!isPendingMachineProviderID(providerID) &&
+		!isFailedMachineProviderID(providerID)
 }
 
 // findNodeByNodeName finds the Node object keyed by name.. Returns
@@ -678,7 +692,7 @@ func (c *machineController) findScalableResourceProviderIDs(scalableResource *un
 
 		if !found {
 			klog.V(4).Infof("Status.NodeRef of machine %q is currently nil", machine.GetName())
-			providerIDs = append(providerIDs, fmt.Sprintf("%s%s_%s", pendingMachinePrefix, machine.GetNamespace(), machine.GetName()))
+			providerIDs = append(providerIDs, createPendingMachineProviderID(machine.GetNamespace(), machine.GetName()))
 			continue
 		}
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -384,10 +384,10 @@ func machineKeyFromFailedProviderID(providerID normalizedProviderID) string {
 	return strings.Replace(namespaceName, "_", "/", 1)
 }
 
-// nodeHasValidProviderID determines whether a node's providerID is the standard
+// isProviderIDNormalized determines whether a node's providerID is the standard
 // providerID assigned by the cloud provider, or if it has
 // been modified by the CAS CAPI provider to indicate deleting, pending, or failed
-func nodeHasValidProviderID(providerID normalizedProviderID) bool {
+func isProviderIDNormalized(providerID normalizedProviderID) bool {
 	return !isDeletingMachineProviderID(providerID) &&
 		!isPendingMachineProviderID(providerID) &&
 		!isFailedMachineProviderID(providerID)

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -639,6 +639,7 @@ func (c *machineController) findScalableResourceProviderIDs(scalableResource *un
 	}
 
 	for _, machine := range machines {
+		// Failed Machines
 		// In some cases it is possible for a machine to have acquired a provider ID from the infrastructure and
 		// then become failed later. We want to ensure that a failed machine is not counted towards the total
 		// number of nodes in the cluster, for this reason we will detect a failed machine first, regardless
@@ -649,42 +650,35 @@ func (c *machineController) findScalableResourceProviderIDs(scalableResource *un
 		}
 
 		if found {
-			klog.V(4).Infof("Status.ErrorMessage of machine %q is %q", machine.GetName(), errorMessage)
-			// Provide a fake ID to allow the autoscaler to track machines that will never
+			// Provide a normalized ID to allow the autoscaler to track machines that will never
 			// become nodes and mark the nodegroup unhealthy after maxNodeProvisionTime.
 			// Fake ID needs to be recognised later and converted into a machine key.
 			// Use an underscore as a separator between namespace and name as it is not a
 			// valid character within a namespace name.
+			klog.V(4).Infof("Status.ErrorMessage of machine %q is %q", machine.GetName(), errorMessage)
 			providerIDs = append(providerIDs, createFailedMachineNormalizedProviderID(machine.GetNamespace(), machine.GetName()))
 			continue
 		}
 
-		// Next we check for the provider ID. Machines with a provider ID can fall into one of a few
-		// categories: creating, running, deleting, and sometimes failed (but we filtered those earlier).
-		// Depending on which category the machine is in, it might have a deleting or pending guard
-		// added to it's provider ID so that we can later properly filter machines.
-		providerID, found, err := unstructured.NestedString(machine.UnstructuredContent(), "spec", "providerID")
-		if err != nil {
-			return nil, err
+		// Deleting Machines
+		// Machines that are in deleting state should be identified so that in scenarios where the core
+		// autoscaler would like to adjust the size of a node group, we can give a proper count and
+		// be able to filter machines in that state, regardless of whether they become a node or not.
+		// We give these machines normalized provider IDs to aid in the filtering process.
+		if !machine.GetDeletionTimestamp().IsZero() {
+			klog.V(4).Infof("Machine %q has a non-zero deletion timestamp", machine.GetName())
+			providerIDs = append(providerIDs, createDeletingMachineNormalizedProviderID(machine.GetNamespace(), machine.GetName()))
+			continue
 		}
 
-		if found {
-			if providerID != "" {
-				// If the machine is deleting, prepend the deletion guard on the provider id
-				// so that it can be properly filtered when counting the number of nodes and instances.
-				if !machine.GetDeletionTimestamp().IsZero() {
-					klog.V(4).Infof("Machine %q has a non-zero deletion timestamp", machine.GetName())
-					providerID = createDeletingMachineNormalizedProviderID(machine.GetNamespace(), machine.GetName())
-				}
-				providerIDs = append(providerIDs, providerID)
-				continue
-			}
-		}
-
-		klog.Warningf("Machine %q has no providerID", machine.GetName())
-
-		// Look for a node reference in the status, a machine with a provider ID but no node reference has not
-		// yet become a node and should be marked as pending.
+		// Pending Machines
+		// Machines that do not yet have an associated node reference are considering to be pending. These
+		// nodes need to be filtered so that in a case where a machine is not becoming a node, or the instance
+		// lifecycle has changed during provisioning (eg spot instance going away), or the core autoscaler has
+		// decided that the node is not needed.
+		// Look for a node reference in the status, a machine without a node reference, and that is also not
+		// in failed or deleting state, has not yet become a node, and should be marked as pending.
+		// We give these machines normalized provider IDs to aid in the filtering process.
 		_, found, err = unstructured.NestedFieldCopy(machine.UnstructuredContent(), "status", "nodeRef")
 		if err != nil {
 			return nil, err
@@ -696,6 +690,29 @@ func (c *machineController) findScalableResourceProviderIDs(scalableResource *un
 			continue
 		}
 
+		// Running Machines
+		// We have filtered out the machines in failed, deleting, and pending states. We now check the provider
+		// ID and potentially the node reference details. It is ok for a machine not to have a provider ID as
+		// not all CAPI provider implement this field, but a machine in running state should have a valid
+		// node reference. If a provider ID is present, we add that to the list as we know it is not failed,
+		// deleting, or pending. If an empty provider ID is present, we check the node details to ensure that
+		// the machine references a valid node.
+		providerID, found, err := unstructured.NestedString(machine.UnstructuredContent(), "spec", "providerID")
+		if err != nil {
+			return nil, err
+		}
+
+		if found {
+			if providerID != "" {
+				// Machine has a provider ID, add it to the list
+				providerIDs = append(providerIDs, providerID)
+				continue
+			}
+		}
+
+		klog.Warningf("Machine %q has no providerID", machine.GetName())
+
+		// Begin checking to determine if the node reference is valid
 		nodeRefKind, found, err := unstructured.NestedString(machine.UnstructuredContent(), "status", "nodeRef", "kind")
 		if err != nil {
 			return nil, err
@@ -717,6 +734,8 @@ func (c *machineController) findScalableResourceProviderIDs(scalableResource *un
 				return nil, fmt.Errorf("unknown node %q", nodeRefName)
 			}
 
+			// A node has been found that corresponds to this machine, since we know that this machine has
+			// an empty provider ID, we add the provider ID from the node to the list.
 			if node != nil {
 				providerIDs = append(providerIDs, node.Spec.ProviderID)
 			}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -2240,7 +2240,7 @@ func TestNodeHasValidProviderID(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			observed := nodeHasValidProviderID(tc.providerID)
+			observed := isProviderIDNormalized(tc.providerID)
 			if observed != tc.expectedReturn {
 				t.Fatalf("unexpected return for provider ID %q, expected %t, observed %t", tc.providerID, tc.expectedReturn, observed)
 			}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -1357,19 +1357,6 @@ func TestControllerMachineSetNodeNamesUsingProviderID(t *testing.T) {
 	controller, stop := mustCreateTestController(t, testConfig)
 	defer stop()
 
-	// Remove Status.NodeRef.Name on all the machines. We want to
-	// force machineSetNodeNames() to only consider the provider
-	// ID for lookups.
-	for i := range testConfig.machines {
-		machine := testConfig.machines[i].DeepCopy()
-
-		unstructured.RemoveNestedField(machine.Object, "status", "nodeRef")
-
-		if err := updateResource(controller.managementClient, controller.machineInformer, controller.machineResource, machine); err != nil {
-			t.Fatalf("unexpected error updating machine, got %v", err)
-		}
-	}
-
 	nodegroups, err := controller.nodeGroups()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -2205,6 +2205,49 @@ func Test_isDeletingMachineProviderID(t *testing.T) {
 
 }
 
+// TestNodeHasValidProviderID tests all permutations of provider IDs
+// to determine whether the providerID is the standard cloud provider ID
+// or has been modified by CAS CAPI provider
+func TestNodeHasValidProviderID(t *testing.T) {
+	type testCase struct {
+		description    string
+		providerID     normalizedProviderID
+		expectedReturn bool
+	}
+
+	testCases := []testCase{
+		{
+			description:    "real looking provider ID should return true",
+			providerID:     normalizedProviderID("fake-provider://a.provider.id-0001"),
+			expectedReturn: true,
+		},
+		{
+			description:    "provider ID created with createDeletingMachineNormalizedProviderID should return false",
+			providerID:     normalizedProviderID(createDeletingMachineNormalizedProviderID("cluster-api", "id-0001")),
+			expectedReturn: false,
+		},
+		{
+			description:    "provider ID created with createPendingDeletionMachineNormalizedProviderID should return false",
+			providerID:     normalizedProviderID(createPendingMachineProviderID("cluster-api", "id-0001")),
+			expectedReturn: false,
+		},
+		{
+			description:    "provider ID created with createFailedMachineNormalizedProviderID should return false",
+			providerID:     normalizedProviderID(createFailedMachineNormalizedProviderID("cluster-api", "id-0001")),
+			expectedReturn: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			observed := nodeHasValidProviderID(tc.providerID)
+			if observed != tc.expectedReturn {
+				t.Fatalf("unexpected return for provider ID %q, expected %t, observed %t", tc.providerID, tc.expectedReturn, observed)
+			}
+		})
+	}
+}
+
 func Test_machineKeyFromDeletingMachineProviderID(t *testing.T) {
 	type testCase struct {
 		description    string
@@ -2270,6 +2313,34 @@ func Test_createDeletingMachineNormalizedProviderID(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			observed := createDeletingMachineNormalizedProviderID(tc.namespace, tc.name)
+			if observed != tc.expectedReturn {
+				t.Fatalf("unexpected return for (namespace %q, name %q), expected %q, observed %q", tc.namespace, tc.name, tc.expectedReturn, observed)
+			}
+		})
+	}
+}
+
+// Test_createPendingMachineProviderID tests the creation of a pending machine provider ID
+func Test_createPendingMachineProviderID(t *testing.T) {
+	type testCase struct {
+		description    string
+		namespace      string
+		name           string
+		expectedReturn string
+	}
+
+	testCases := []testCase{
+		{
+			description:    "namespace and name return proper normalized ID",
+			namespace:      "cluster-api",
+			name:           "id-0001",
+			expectedReturn: fmt.Sprintf("%s%s_%s", pendingMachinePrefix, "cluster-api", "id-0001"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			observed := createPendingMachineProviderID(tc.namespace, tc.name)
 			if observed != tc.expectedReturn {
 				t.Fatalf("unexpected return for (namespace %q, name %q), expected %q, observed %q", tc.namespace, tc.name, tc.expectedReturn, observed)
 			}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -207,9 +207,7 @@ func (ng *nodegroup) DecreaseTargetSize(delta int) error {
 	// provider.
 	actualNodes := 0
 	for _, node := range nodes {
-		if !isPendingMachineProviderID(normalizedProviderID(node.Id)) &&
-			!isFailedMachineProviderID(normalizedProviderID(node.Id)) &&
-			!isDeletingMachineProviderID(normalizedProviderID(node.Id)) {
+		if nodeHasValidProviderID(normalizedProviderID(node.Id)) {
 			actualNodes += 1
 		}
 	}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -207,7 +207,7 @@ func (ng *nodegroup) DecreaseTargetSize(delta int) error {
 	// provider.
 	actualNodes := 0
 	for _, node := range nodes {
-		if nodeHasValidProviderID(normalizedProviderID(node.Id)) {
+		if isProviderIDNormalized(normalizedProviderID(node.Id)) {
 			actualNodes += 1
 		}
 	}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -406,16 +406,18 @@ func TestNodeGroupIncreaseSize(t *testing.T) {
 
 func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 	type testCase struct {
-		description                        string
-		delta                              int
-		initial                            int32
-		targetSizeIncrement                int32
-		expected                           int32
-		expectedError                      bool
-		includeDeletingMachine             bool
-		includeFailedMachine               bool
-		includeFailedMachineWithProviderID bool
-		includePendingMachine              bool
+		description                         string
+		delta                               int
+		initial                             int32
+		targetSizeIncrement                 int32
+		expected                            int32
+		expectedError                       bool
+		includeDeletingMachine              bool
+		includeFailedMachine                bool
+		includeFailedMachineWithProviderID  bool
+		includePendingMachine               bool
+		includePendingMachineWithProviderID bool
+		machinesDoNotHaveProviderIDs        bool
 	}
 
 	test := func(t *testing.T, tc *testCase, testConfig *testConfig) {
@@ -468,11 +470,24 @@ func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 			// Simulate a pending machine
 			machine := testConfig.machines[2].DeepCopy()
 
-			unstructured.RemoveNestedField(machine.Object, "spec", "providerID")
+			if !tc.includePendingMachineWithProviderID {
+				unstructured.RemoveNestedField(machine.Object, "spec", "providerID")
+			}
 			unstructured.RemoveNestedField(machine.Object, "status", "nodeRef")
 
 			if err := updateResource(controller.managementClient, controller.machineInformer, controller.machineResource, machine); err != nil {
 				t.Fatalf("unexpected error updating machine, got %v", err)
+			}
+		}
+
+		// machines with no provider id can be created on some providers, notably bare metal
+		if tc.machinesDoNotHaveProviderIDs {
+			for _, machine := range testConfig.machines {
+				updated := machine.DeepCopy()
+				unstructured.RemoveNestedField(updated.Object, "spec", "providerID")
+				if err := updateResource(controller.managementClient, controller.machineInformer, controller.machineResource, updated); err != nil {
+					t.Fatalf("unexpected error updating machine, got %v", err)
+				}
 			}
 		}
 
@@ -647,6 +662,23 @@ func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 			delta:                              -1,
 			includeFailedMachine:               true,
 			includeFailedMachineWithProviderID: true,
+		},
+		{
+			description:                         "A node group with 4 replicas with one pending machine that has a provider ID should decrease by 1",
+			initial:                             4,
+			targetSizeIncrement:                 0,
+			expected:                            3,
+			delta:                               -1,
+			includePendingMachine:               true,
+			includePendingMachineWithProviderID: true,
+		},
+		{
+			description:                  "A node group with target size 4 but only 3 existing instances without provider IDs should decrease by 1",
+			initial:                      3,
+			targetSizeIncrement:          1,
+			expected:                     3,
+			delta:                        -1,
+			machinesDoNotHaveProviderIDs: true,
 		},
 	}
 


### PR DESCRIPTION
this change bring in the upstream kubernetes/autoscaler#7952 and kubernetes/autoscaler#7977