### PR TITLE
[release-4.16] OCPBUGS-54326:  improve replica counting and decrease target size behavior

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -381,10 +381,10 @@ func machineKeyFromFailedProviderID(providerID normalizedProviderID) string {
 	return strings.Replace(namespaceName, "_", "/", 1)
 }
 
-// nodeHasValidProviderID determines whether a node's providerID is the standard
+// isProviderIDNormalized determines whether a node's providerID is the standard
 // providerID assigned by the cloud provider, or if it has
 // been modified by the CAS CAPI provider to indicate deleting, pending, or failed
-func nodeHasValidProviderID(providerID normalizedProviderID) bool {
+func isProviderIDNormalized(providerID normalizedProviderID) bool {
 	return !isDeletingMachineProviderID(providerID) &&
 		!isPendingMachineProviderID(providerID) &&
 		!isFailedMachineProviderID(providerID)

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -55,6 +55,7 @@ const (
 	resourceNameMachineSet        = "machinesets"
 	resourceNameMachineDeployment = "machinedeployments"
 	resourceNameMachinePool       = "machinepools"
+	deletingMachinePrefix         = "deleting-machine-"
 	failedMachinePrefix           = "failed-machine-"
 	pendingMachinePrefix          = "pending-machine-"
 	machineTemplateKind           = "MachineTemplate"
@@ -313,6 +314,9 @@ func (c *machineController) findMachineByProviderID(providerID normalizedProvide
 		return u.DeepCopy(), nil
 	}
 
+	if isDeletingMachineProviderID(providerID) {
+		return c.findMachine(machineKeyFromDeletingMachineProviderID(providerID))
+	}
 	if isFailedMachineProviderID(providerID) {
 		return c.findMachine(machineKeyFromFailedProviderID(providerID))
 	}
@@ -335,6 +339,19 @@ func (c *machineController) findMachineByProviderID(providerID normalizedProvide
 
 	machineID := node.Annotations[machineAnnotationKey]
 	return c.findMachine(machineID)
+}
+
+func createDeletingMachineNormalizedProviderID(namespace, name string) string {
+	return fmt.Sprintf("%s%s_%s", deletingMachinePrefix, namespace, name)
+}
+
+func isDeletingMachineProviderID(providerID normalizedProviderID) bool {
+	return strings.HasPrefix(string(providerID), deletingMachinePrefix)
+}
+
+func machineKeyFromDeletingMachineProviderID(providerID normalizedProviderID) string {
+	namespaceName := strings.TrimPrefix(string(providerID), deletingMachinePrefix)
+	return strings.Replace(namespaceName, "_", "/", 1)
 }
 
 func isPendingMachineProviderID(providerID normalizedProviderID) bool {
@@ -606,6 +623,12 @@ func (c *machineController) findScalableResourceProviderIDs(scalableResource *un
 
 		if found {
 			if providerID != "" {
+				// If the machine is deleting, prepend the deletion guard on the provider id
+				// so that it can be properly filtered when counting the number of nodes and instances.
+				if !machine.GetDeletionTimestamp().IsZero() {
+					klog.V(4).Infof("Machine %q has a non-zero deletion timestamp", machine.GetName())
+					providerID = createDeletingMachineNormalizedProviderID(machine.GetNamespace(), machine.GetName())
+				}
 				providerIDs = append(providerIDs, providerID)
 				continue
 			}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -46,6 +46,7 @@ const (
 	machinePoolProviderIDIndex = "machinePoolProviderIDIndex"
 	nodeProviderIDIndex        = "nodeProviderIDIndex"
 	defaultCAPIGroup           = "cluster.x-k8s.io"
+	openshiftMAPIGroup         = "machine.openshift.io"
 	// CAPIGroupEnvVar contains the environment variable name which allows overriding defaultCAPIGroup.
 	CAPIGroupEnvVar = "CAPI_GROUP"
 	// CAPIVersionEnvVar contains the environment variable name which allows overriding the Cluster API group version.

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -634,6 +634,7 @@ func (c *machineController) findScalableResourceProviderIDs(scalableResource *un
 	}
 
 	for _, machine := range machines {
+		// Failed Machines
 		// In some cases it is possible for a machine to have acquired a provider ID from the infrastructure and
 		// then become failed later. We want to ensure that a failed machine is not counted towards the total
 		// number of nodes in the cluster, for this reason we will detect a failed machine first, regardless
@@ -644,42 +645,35 @@ func (c *machineController) findScalableResourceProviderIDs(scalableResource *un
 		}
 
 		if found {
-			klog.V(4).Infof("Status.ErrorMessage of machine %q is %q", machine.GetName(), errorMessage)
-			// Provide a fake ID to allow the autoscaler to track machines that will never
+			// Provide a normalized ID to allow the autoscaler to track machines that will never
 			// become nodes and mark the nodegroup unhealthy after maxNodeProvisionTime.
 			// Fake ID needs to be recognised later and converted into a machine key.
 			// Use an underscore as a separator between namespace and name as it is not a
 			// valid character within a namespace name.
+			klog.V(4).Infof("Status.ErrorMessage of machine %q is %q", machine.GetName(), errorMessage)
 			providerIDs = append(providerIDs, createFailedMachineNormalizedProviderID(machine.GetNamespace(), machine.GetName()))
 			continue
 		}
 
-		// Next we check for the provider ID. Machines with a provider ID can fall into one of a few
-		// categories: creating, running, deleting, and sometimes failed (but we filtered those earlier).
-		// Depending on which category the machine is in, it might have a deleting or pending guard
-		// added to it's provider ID so that we can later properly filter machines.
-		providerID, found, err := unstructured.NestedString(machine.UnstructuredContent(), "spec", "providerID")
-		if err != nil {
-			return nil, err
+		// Deleting Machines
+		// Machines that are in deleting state should be identified so that in scenarios where the core
+		// autoscaler would like to adjust the size of a node group, we can give a proper count and
+		// be able to filter machines in that state, regardless of whether they become a node or not.
+		// We give these machines normalized provider IDs to aid in the filtering process.
+		if !machine.GetDeletionTimestamp().IsZero() {
+			klog.V(4).Infof("Machine %q has a non-zero deletion timestamp", machine.GetName())
+			providerIDs = append(providerIDs, createDeletingMachineNormalizedProviderID(machine.GetNamespace(), machine.GetName()))
+			continue
 		}
 
-		if found {
-			if providerID != "" {
-				// If the machine is deleting, prepend the deletion guard on the provider id
-				// so that it can be properly filtered when counting the number of nodes and instances.
-				if !machine.GetDeletionTimestamp().IsZero() {
-					klog.V(4).Infof("Machine %q has a non-zero deletion timestamp", machine.GetName())
-					providerID = createDeletingMachineNormalizedProviderID(machine.GetNamespace(), machine.GetName())
-				}
-				providerIDs = append(providerIDs, providerID)
-				continue
-			}
-		}
-
-		klog.Warningf("Machine %q has no providerID", machine.GetName())
-
-		// Look for a node reference in the status, a machine with a provider ID but no node reference has not
-		// yet become a node and should be marked as pending.
+		// Pending Machines
+		// Machines that do not yet have an associated node reference are considering to be pending. These
+		// nodes need to be filtered so that in a case where a machine is not becoming a node, or the instance
+		// lifecycle has changed during provisioning (eg spot instance going away), or the core autoscaler has
+		// decided that the node is not needed.
+		// Look for a node reference in the status, a machine without a node reference, and that is also not
+		// in failed or deleting state, has not yet become a node, and should be marked as pending.
+		// We give these machines normalized provider IDs to aid in the filtering process.
 		_, found, err = unstructured.NestedFieldCopy(machine.UnstructuredContent(), "status", "nodeRef")
 		if err != nil {
 			return nil, err
@@ -691,6 +685,29 @@ func (c *machineController) findScalableResourceProviderIDs(scalableResource *un
 			continue
 		}
 
+		// Running Machines
+		// We have filtered out the machines in failed, deleting, and pending states. We now check the provider
+		// ID and potentially the node reference details. It is ok for a machine not to have a provider ID as
+		// not all CAPI provider implement this field, but a machine in running state should have a valid
+		// node reference. If a provider ID is present, we add that to the list as we know it is not failed,
+		// deleting, or pending. If an empty provider ID is present, we check the node details to ensure that
+		// the machine references a valid node.
+		providerID, found, err := unstructured.NestedString(machine.UnstructuredContent(), "spec", "providerID")
+		if err != nil {
+			return nil, err
+		}
+
+		if found {
+			if providerID != "" {
+				// Machine has a provider ID, add it to the list
+				providerIDs = append(providerIDs, providerID)
+				continue
+			}
+		}
+
+		klog.Warningf("Machine %q has no providerID", machine.GetName())
+
+		// Begin checking to determine if the node reference is valid
 		nodeRefKind, found, err := unstructured.NestedString(machine.UnstructuredContent(), "status", "nodeRef", "kind")
 		if err != nil {
 			return nil, err
@@ -712,6 +729,8 @@ func (c *machineController) findScalableResourceProviderIDs(scalableResource *un
 				return nil, fmt.Errorf("unknown node %q", nodeRefName)
 			}
 
+			// A node has been found that corresponds to this machine, since we know that this machine has
+			// an empty provider ID, we add the provider ID from the node to the list.
 			if node != nil {
 				providerIDs = append(providerIDs, node.Spec.ProviderID)
 			}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -363,6 +363,10 @@ func machineKeyFromPendingMachineProviderID(providerID normalizedProviderID) str
 	return strings.Replace(namespaceName, "_", "/", 1)
 }
 
+func createFailedMachineNormalizedProviderID(namespace, name string) string {
+	return fmt.Sprintf("%s%s_%s", failedMachinePrefix, namespace, name)
+}
+
 func isFailedMachineProviderID(providerID normalizedProviderID) bool {
 	return strings.HasPrefix(string(providerID), failedMachinePrefix)
 }
@@ -616,6 +620,30 @@ func (c *machineController) findScalableResourceProviderIDs(scalableResource *un
 	}
 
 	for _, machine := range machines {
+		// In some cases it is possible for a machine to have acquired a provider ID from the infrastructure and
+		// then become failed later. We want to ensure that a failed machine is not counted towards the total
+		// number of nodes in the cluster, for this reason we will detect a failed machine first, regardless
+		// of provider ID, and give it a normalized provider ID with failure message prepended.
+		errorMessage, found, err := unstructured.NestedString(machine.UnstructuredContent(), "status", "errorMessage")
+		if err != nil {
+			return nil, err
+		}
+
+		if found {
+			klog.V(4).Infof("Status.ErrorMessage of machine %q is %q", machine.GetName(), errorMessage)
+			// Provide a fake ID to allow the autoscaler to track machines that will never
+			// become nodes and mark the nodegroup unhealthy after maxNodeProvisionTime.
+			// Fake ID needs to be recognised later and converted into a machine key.
+			// Use an underscore as a separator between namespace and name as it is not a
+			// valid character within a namespace name.
+			providerIDs = append(providerIDs, createFailedMachineNormalizedProviderID(machine.GetNamespace(), machine.GetName()))
+			continue
+		}
+
+		// Next we check for the provider ID. Machines with a provider ID can fall into one of a few
+		// categories: creating, running, deleting, and sometimes failed (but we filtered those earlier).
+		// Depending on which category the machine is in, it might have a deleting or pending guard
+		// added to it's provider ID so that we can later properly filter machines.
 		providerID, found, err := unstructured.NestedString(machine.UnstructuredContent(), "spec", "providerID")
 		if err != nil {
 			return nil, err
@@ -636,22 +664,8 @@ func (c *machineController) findScalableResourceProviderIDs(scalableResource *un
 
 		klog.Warningf("Machine %q has no providerID", machine.GetName())
 
-		errorMessage, found, err := unstructured.NestedString(machine.UnstructuredContent(), "status", "errorMessage")
-		if err != nil {
-			return nil, err
-		}
-
-		if found {
-			klog.V(4).Infof("Status.ErrorMessage of machine %q is %q", machine.GetName(), errorMessage)
-			// Provide a fake ID to allow the autoscaler to track machines that will never
-			// become nodes and mark the nodegroup unhealthy after maxNodeProvisionTime.
-			// Fake ID needs to be recognised later and converted into a machine key.
-			// Use an underscore as a separator between namespace and name as it is not a
-			// valid character within a namespace name.
-			providerIDs = append(providerIDs, fmt.Sprintf("%s%s_%s", failedMachinePrefix, machine.GetNamespace(), machine.GetName()))
-			continue
-		}
-
+		// Look for a node reference in the status, a machine with a provider ID but no node reference has not
+		// yet become a node and should be marked as pending.
 		_, found, err = unstructured.NestedFieldCopy(machine.UnstructuredContent(), "status", "nodeRef")
 		if err != nil {
 			return nil, err

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -354,6 +354,11 @@ func machineKeyFromDeletingMachineProviderID(providerID normalizedProviderID) st
 	return strings.Replace(namespaceName, "_", "/", 1)
 }
 
+// createPendingMachineProviderID creates a providerID for a machine that is pending
+func createPendingMachineProviderID(namespace, name string) string {
+	return fmt.Sprintf("%s%s_%s", pendingMachinePrefix, namespace, name)
+}
+
 func isPendingMachineProviderID(providerID normalizedProviderID) bool {
 	return strings.HasPrefix(string(providerID), pendingMachinePrefix)
 }
@@ -374,6 +379,15 @@ func isFailedMachineProviderID(providerID normalizedProviderID) bool {
 func machineKeyFromFailedProviderID(providerID normalizedProviderID) string {
 	namespaceName := strings.TrimPrefix(string(providerID), failedMachinePrefix)
 	return strings.Replace(namespaceName, "_", "/", 1)
+}
+
+// nodeHasValidProviderID determines whether a node's providerID is the standard
+// providerID assigned by the cloud provider, or if it has
+// been modified by the CAS CAPI provider to indicate deleting, pending, or failed
+func nodeHasValidProviderID(providerID normalizedProviderID) bool {
+	return !isDeletingMachineProviderID(providerID) &&
+		!isPendingMachineProviderID(providerID) &&
+		!isFailedMachineProviderID(providerID)
 }
 
 // findNodeByNodeName finds the Node object keyed by name.. Returns
@@ -673,7 +687,7 @@ func (c *machineController) findScalableResourceProviderIDs(scalableResource *un
 
 		if !found {
 			klog.V(4).Infof("Status.NodeRef of machine %q is currently nil", machine.GetName())
-			providerIDs = append(providerIDs, fmt.Sprintf("%s%s_%s", pendingMachinePrefix, machine.GetNamespace(), machine.GetName()))
+			providerIDs = append(providerIDs, createPendingMachineProviderID(machine.GetNamespace(), machine.GetName()))
 			continue
 		}
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -2152,3 +2152,116 @@ func Test_machineController_nodeGroups(t *testing.T) {
 		})
 	}
 }
+
+func Test_isDeletingMachineProviderID(t *testing.T) {
+	type testCase struct {
+		description    string
+		providerID     string
+		expectedReturn bool
+	}
+
+	testCases := []testCase{
+		{
+			description:    "proper provider ID without deletion prefix should return false",
+			providerID:     "fake-provider://a.provider.id-0001",
+			expectedReturn: false,
+		},
+		{
+			description:    "provider ID with deletion prefix should return true",
+			providerID:     fmt.Sprintf("%s%s_%s", deletingMachinePrefix, "cluster-api", "id-0001"),
+			expectedReturn: true,
+		},
+		{
+			description:    "empty provider ID should return false",
+			providerID:     "",
+			expectedReturn: false,
+		},
+		{
+			description:    "provider ID created with createDeletingMachineNormalizedProviderID returns true",
+			providerID:     createDeletingMachineNormalizedProviderID("cluster-api", "id-0001"),
+			expectedReturn: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			observed := isDeletingMachineProviderID(normalizedProviderID(tc.providerID))
+			if observed != tc.expectedReturn {
+				t.Fatalf("unexpected return for provider ID %q, expected %t, observed %t", tc.providerID, tc.expectedReturn, observed)
+			}
+		})
+	}
+
+}
+
+func Test_machineKeyFromDeletingMachineProviderID(t *testing.T) {
+	type testCase struct {
+		description    string
+		providerID     string
+		expectedReturn string
+	}
+
+	testCases := []testCase{
+		{
+			description:    "real looking provider ID with no deletion prefix returns provider id",
+			providerID:     "fake-provider://a.provider.id-0001",
+			expectedReturn: "fake-provider://a.provider.id-0001",
+		},
+		{
+			description:    "namespace_name provider ID with no deletion prefix returns proper provider ID",
+			providerID:     "cluster-api_id-0001",
+			expectedReturn: "cluster-api/id-0001",
+		},
+		{
+			description:    "namespace_name provider ID with deletion prefix returns proper provider ID",
+			providerID:     fmt.Sprintf("%s%s_%s", deletingMachinePrefix, "cluster-api", "id-0001"),
+			expectedReturn: "cluster-api/id-0001",
+		},
+		{
+			description:    "namespace_name provider ID with deletion prefix and two underscores returns proper provider ID",
+			providerID:     fmt.Sprintf("%s%s_%s", deletingMachinePrefix, "cluster-api", "id_0001"),
+			expectedReturn: "cluster-api/id_0001",
+		},
+		{
+			description:    "provider ID created with createDeletingMachineNormalizedProviderID returns proper provider ID",
+			providerID:     createDeletingMachineNormalizedProviderID("cluster-api", "id-0001"),
+			expectedReturn: "cluster-api/id-0001",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			observed := machineKeyFromDeletingMachineProviderID(normalizedProviderID(tc.providerID))
+			if observed != tc.expectedReturn {
+				t.Fatalf("unexpected return for provider ID %q, expected %q, observed %q", tc.providerID, tc.expectedReturn, observed)
+			}
+		})
+	}
+}
+
+func Test_createDeletingMachineNormalizedProviderID(t *testing.T) {
+	type testCase struct {
+		description    string
+		namespace      string
+		name           string
+		expectedReturn string
+	}
+
+	testCases := []testCase{
+		{
+			description:    "namespace and name return proper normalized ID",
+			namespace:      "cluster-api",
+			name:           "id-0001",
+			expectedReturn: fmt.Sprintf("%s%s_%s", deletingMachinePrefix, "cluster-api", "id-0001"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			observed := createDeletingMachineNormalizedProviderID(tc.namespace, tc.name)
+			if observed != tc.expectedReturn {
+				t.Fatalf("unexpected return for (namespace %q, name %q), expected %q, observed %q", tc.namespace, tc.name, tc.expectedReturn, observed)
+			}
+		})
+	}
+}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -2204,6 +2204,49 @@ func Test_isDeletingMachineProviderID(t *testing.T) {
 
 }
 
+// TestNodeHasValidProviderID tests all permutations of provider IDs
+// to determine whether the providerID is the standard cloud provider ID
+// or has been modified by CAS CAPI provider
+func TestNodeHasValidProviderID(t *testing.T) {
+	type testCase struct {
+		description    string
+		providerID     normalizedProviderID
+		expectedReturn bool
+	}
+
+	testCases := []testCase{
+		{
+			description:    "real looking provider ID should return true",
+			providerID:     normalizedProviderID("fake-provider://a.provider.id-0001"),
+			expectedReturn: true,
+		},
+		{
+			description:    "provider ID created with createDeletingMachineNormalizedProviderID should return false",
+			providerID:     normalizedProviderID(createDeletingMachineNormalizedProviderID("cluster-api", "id-0001")),
+			expectedReturn: false,
+		},
+		{
+			description:    "provider ID created with createPendingDeletionMachineNormalizedProviderID should return false",
+			providerID:     normalizedProviderID(createPendingMachineProviderID("cluster-api", "id-0001")),
+			expectedReturn: false,
+		},
+		{
+			description:    "provider ID created with createFailedMachineNormalizedProviderID should return false",
+			providerID:     normalizedProviderID(createFailedMachineNormalizedProviderID("cluster-api", "id-0001")),
+			expectedReturn: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			observed := nodeHasValidProviderID(tc.providerID)
+			if observed != tc.expectedReturn {
+				t.Fatalf("unexpected return for provider ID %q, expected %t, observed %t", tc.providerID, tc.expectedReturn, observed)
+			}
+		})
+	}
+}
+
 func Test_machineKeyFromDeletingMachineProviderID(t *testing.T) {
 	type testCase struct {
 		description    string
@@ -2269,6 +2312,34 @@ func Test_createDeletingMachineNormalizedProviderID(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			observed := createDeletingMachineNormalizedProviderID(tc.namespace, tc.name)
+			if observed != tc.expectedReturn {
+				t.Fatalf("unexpected return for (namespace %q, name %q), expected %q, observed %q", tc.namespace, tc.name, tc.expectedReturn, observed)
+			}
+		})
+	}
+}
+
+// Test_createPendingMachineProviderID tests the creation of a pending machine provider ID
+func Test_createPendingMachineProviderID(t *testing.T) {
+	type testCase struct {
+		description    string
+		namespace      string
+		name           string
+		expectedReturn string
+	}
+
+	testCases := []testCase{
+		{
+			description:    "namespace and name return proper normalized ID",
+			namespace:      "cluster-api",
+			name:           "id-0001",
+			expectedReturn: fmt.Sprintf("%s%s_%s", pendingMachinePrefix, "cluster-api", "id-0001"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			observed := createPendingMachineProviderID(tc.namespace, tc.name)
 			if observed != tc.expectedReturn {
 				t.Fatalf("unexpected return for (namespace %q, name %q), expected %q, observed %q", tc.namespace, tc.name, tc.expectedReturn, observed)
 			}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -2239,7 +2239,7 @@ func TestNodeHasValidProviderID(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			observed := nodeHasValidProviderID(tc.providerID)
+			observed := isProviderIDNormalized(tc.providerID)
 			if observed != tc.expectedReturn {
 				t.Fatalf("unexpected return for provider ID %q, expected %t, observed %t", tc.providerID, tc.expectedReturn, observed)
 			}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -1356,19 +1356,6 @@ func TestControllerMachineSetNodeNamesUsingProviderID(t *testing.T) {
 	controller, stop := mustCreateTestController(t, testConfig)
 	defer stop()
 
-	// Remove Status.NodeRef.Name on all the machines. We want to
-	// force machineSetNodeNames() to only consider the provider
-	// ID for lookups.
-	for i := range testConfig.machines {
-		machine := testConfig.machines[i].DeepCopy()
-
-		unstructured.RemoveNestedField(machine.Object, "status", "nodeRef")
-
-		if err := updateResource(controller.managementClient, controller.machineInformer, controller.machineResource, machine); err != nil {
-			t.Fatalf("unexpected error updating machine, got %v", err)
-		}
-	}
-
 	nodegroups, err := controller.nodeGroups()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller_test.go
@@ -1685,6 +1685,11 @@ func TestIsFailedMachineProviderID(t *testing.T) {
 			providerID: normalizedProviderID("foo"),
 			expected:   false,
 		},
+		{
+			name:       "with provider ID created by createFailedMachineNormalizedProviderID should return true",
+			providerID: normalizedProviderID(createFailedMachineNormalizedProviderID("cluster-api", "id-0001")),
+			expected:   true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1711,6 +1716,11 @@ func TestMachineKeyFromFailedProviderID(t *testing.T) {
 			name:       "with a machine with an underscore in the name",
 			providerID: normalizedProviderID(fmt.Sprintf("%stest-namespace_foo_bar", failedMachinePrefix)),
 			expected:   "test-namespace/foo_bar",
+		},
+		{
+			name:       "with a provider ID created by createFailedMachineNormalizedProviderID",
+			providerID: normalizedProviderID(createFailedMachineNormalizedProviderID("cluster-api", "id-0001")),
+			expected:   "cluster-api/id-0001",
 		},
 	}
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -198,7 +198,7 @@ func (ng *nodegroup) DecreaseTargetSize(delta int) error {
 	// provider.
 	actualNodes := 0
 	for _, node := range nodes {
-		if nodeHasValidProviderID(normalizedProviderID(node.Id)) {
+		if isProviderIDNormalized(normalizedProviderID(node.Id)) {
 			actualNodes += 1
 		}
 	}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -198,9 +198,7 @@ func (ng *nodegroup) DecreaseTargetSize(delta int) error {
 	// provider.
 	actualNodes := 0
 	for _, node := range nodes {
-		if !isPendingMachineProviderID(normalizedProviderID(node.Id)) &&
-			!isFailedMachineProviderID(normalizedProviderID(node.Id)) &&
-			!isDeletingMachineProviderID(normalizedProviderID(node.Id)) {
+		if nodeHasValidProviderID(normalizedProviderID(node.Id)) {
 			actualNodes += 1
 		}
 	}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -189,11 +189,28 @@ func (ng *nodegroup) DecreaseTargetSize(delta int) error {
 		return err
 	}
 
-	if size+delta < len(nodes) {
-		return fmt.Errorf("attempt to delete existing nodes targetSize:%d delta:%d existingNodes: %d",
-			size, delta, len(nodes))
+	// we want to filter out machines that are not nodes (eg failed or pending)
+	// so that the node group size can be set properly. this affects situations
+	// where an instance is created, but cannot become a node due to cloud provider
+	// issues such as quota limitations, and thus the autoscaler needs to properly
+	// set the size of the node group. without this adjustment, the core autoscaler
+	// will become confused about the state of nodes and instances in the clusterapi
+	// provider.
+	actualNodes := 0
+	for _, node := range nodes {
+		if !isPendingMachineProviderID(normalizedProviderID(node.Id)) &&
+			!isFailedMachineProviderID(normalizedProviderID(node.Id)) &&
+			!isDeletingMachineProviderID(normalizedProviderID(node.Id)) {
+			actualNodes += 1
+		}
 	}
 
+	if size+delta < actualNodes {
+		return fmt.Errorf("node group %s: attempt to delete existing nodes currentReplicas:%d delta:%d existingNodes: %d",
+			ng.scalableResource.Name(), size, delta, actualNodes)
+	}
+
+	klog.V(4).Infof("%s: DecreaseTargetSize: scaling down: currentReplicas: %d, delta: %d, existingNodes: %d", ng.scalableResource.Name(), size, delta, len(nodes))
 	return ng.scalableResource.SetSize(size + delta)
 }
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	klog "k8s.io/klog/v2"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -240,9 +240,82 @@ func (ng *nodegroup) Nodes() ([]cloudprovider.Instance, error) {
 	// must match the ID on the Node object itself.
 	// https://github.com/kubernetes/autoscaler/blob/a973259f1852303ba38a3a61eeee8489cf4e1b13/cluster-autoscaler/clusterstate/clusterstate.go#L967-L985
 	instances := make([]cloudprovider.Instance, len(providerIDs))
-	for i := range providerIDs {
+	for i, providerID := range providerIDs {
+		providerIDNormalized := normalizedProviderID(providerID)
+
+		// Add instance Status to report instance state to cluster-autoscaler.
+		// This helps cluster-autoscaler make better scaling decisions.
+		//
+		// Machine can be Failed for a variety of reasons, here we are looking for a specific errors:
+		// - Failed to provision
+		// - Failed to delete.
+		// Other reasons for a machine to be in a Failed state are not forwarding Status to the autoscaler.
+		var status *cloudprovider.InstanceStatus
+		switch {
+		case isFailedMachineProviderID(providerIDNormalized):
+			klog.V(4).Infof("Machine failed in node group %s (%s)", ng.Id(), providerID)
+
+			machine, err := ng.machineController.findMachineByProviderID(providerIDNormalized)
+			if err != nil {
+				return nil, err
+			}
+
+			if machine != nil {
+				if !machine.GetDeletionTimestamp().IsZero() {
+					klog.V(4).Infof("Machine failed in node group %s (%s) is being deleted", ng.Id(), providerID)
+					status = &cloudprovider.InstanceStatus{
+						State: cloudprovider.InstanceDeleting,
+						ErrorInfo: &cloudprovider.InstanceErrorInfo{
+							ErrorClass:   cloudprovider.OtherErrorClass,
+							ErrorCode:    "DeletingFailed",
+							ErrorMessage: "Machine deletion failed",
+						},
+					}
+				} else {
+					_, nodeFound, err := unstructured.NestedFieldCopy(machine.UnstructuredContent(), "status", "nodeRef")
+					if err != nil {
+						return nil, err
+					}
+
+					// Machine failed without a nodeRef, this indicates that the machine failed to provision.
+					// This is a special case where the machine is in a Failed state and the node is not created.
+					// Machine controller will not reconcile this machine, so we need to report this to the autoscaler.
+					if !nodeFound {
+						klog.V(4).Infof("Machine failed in node group %s (%s) was being created", ng.Id(), providerID)
+						status = &cloudprovider.InstanceStatus{
+							State: cloudprovider.InstanceCreating,
+							ErrorInfo: &cloudprovider.InstanceErrorInfo{
+								ErrorClass:   cloudprovider.OtherErrorClass,
+								ErrorCode:    "ProvisioningFailed",
+								ErrorMessage: "Machine provisioning failed",
+							},
+						}
+					}
+				}
+			}
+
+		case isPendingMachineProviderID(providerIDNormalized):
+			klog.V(4).Infof("Machine pending in node group %s (%s)", ng.Id(), providerID)
+			status = &cloudprovider.InstanceStatus{
+				State: cloudprovider.InstanceCreating,
+			}
+
+		case isDeletingMachineProviderID(providerIDNormalized):
+			klog.V(4).Infof("Machine deleting in node group %s (%s)", ng.Id(), providerID)
+			status = &cloudprovider.InstanceStatus{
+				State: cloudprovider.InstanceDeleting,
+			}
+
+		default:
+			klog.V(4).Infof("Machine running in node group %s (%s)", ng.Id(), providerID)
+			status = &cloudprovider.InstanceStatus{
+				State: cloudprovider.InstanceRunning,
+			}
+		}
+
 		instances[i] = cloudprovider.Instance{
-			Id: providerIDs[i],
+			Id:     providerID,
+			Status: status,
 		}
 	}
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -394,15 +394,16 @@ func TestNodeGroupIncreaseSize(t *testing.T) {
 
 func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 	type testCase struct {
-		description            string
-		delta                  int
-		initial                int32
-		targetSizeIncrement    int32
-		expected               int32
-		expectedError          bool
-		includeDeletingMachine bool
-		includeFailedMachine   bool
-		includePendingMachine  bool
+		description                        string
+		delta                              int
+		initial                            int32
+		targetSizeIncrement                int32
+		expected                           int32
+		expectedError                      bool
+		includeDeletingMachine             bool
+		includeFailedMachine               bool
+		includeFailedMachineWithProviderID bool
+		includePendingMachine              bool
 	}
 
 	test := func(t *testing.T, tc *testCase, testConfig *testConfig) {
@@ -435,7 +436,9 @@ func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 			// Simulate a failed machine
 			machine := testConfig.machines[1].DeepCopy()
 
-			unstructured.RemoveNestedField(machine.Object, "spec", "providerID")
+			if !tc.includeFailedMachineWithProviderID {
+				unstructured.RemoveNestedField(machine.Object, "spec", "providerID")
+			}
 			unstructured.SetNestedField(machine.Object, "ErrorMessage", "status", "errorMessage")
 
 			if err := updateResource(controller.managementClient, controller.machineInformer, controller.machineResource, machine); err != nil {
@@ -623,6 +626,15 @@ func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 			includeFailedMachine:   true,
 			includePendingMachine:  true,
 			includeDeletingMachine: true,
+		},
+		{
+			description:                        "A node group with 4 replicas with one failed machine that has a provider ID should decrease by 1",
+			initial:                            4,
+			targetSizeIncrement:                0,
+			expected:                           3,
+			delta:                              -1,
+			includeFailedMachine:               true,
+			includeFailedMachineWithProviderID: true,
 		},
 	}
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -394,17 +394,72 @@ func TestNodeGroupIncreaseSize(t *testing.T) {
 
 func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 	type testCase struct {
-		description         string
-		delta               int
-		initial             int32
-		targetSizeIncrement int32
-		expected            int32
-		expectedError       bool
+		description            string
+		delta                  int
+		initial                int32
+		targetSizeIncrement    int32
+		expected               int32
+		expectedError          bool
+		includeDeletingMachine bool
+		includeFailedMachine   bool
+		includePendingMachine  bool
 	}
 
 	test := func(t *testing.T, tc *testCase, testConfig *testConfig) {
 		controller, stop := mustCreateTestController(t, testConfig)
 		defer stop()
+
+		// machines in deletion should not be counted towards the active nodes when calculating a decrease in size.
+		if tc.includeDeletingMachine {
+			if tc.initial < 1 {
+				t.Fatal("test cannot pass, deleted machine requires at least 1 machine in machineset")
+			}
+
+			// Simulate a machine in deleting
+			machine := testConfig.machines[0].DeepCopy()
+			timestamp := metav1.Now()
+			machine.SetDeletionTimestamp(&timestamp)
+
+			if err := updateResource(controller.managementClient, controller.machineInformer, controller.machineResource, machine); err != nil {
+				t.Fatalf("unexpected error updating machine, got %v", err)
+			}
+		}
+
+		// machines that have failed should not be counted towards the active nodes when calculating a decrease in size.
+		if tc.includeFailedMachine {
+			// because we want to allow for tests that have deleted machines and failed machines, we use the second machine in the test data.
+			if tc.initial < 2 {
+				t.Fatal("test cannot pass, failed machine requires at least 2 machine in machineset")
+			}
+
+			// Simulate a failed machine
+			machine := testConfig.machines[1].DeepCopy()
+
+			unstructured.RemoveNestedField(machine.Object, "spec", "providerID")
+			unstructured.SetNestedField(machine.Object, "ErrorMessage", "status", "errorMessage")
+
+			if err := updateResource(controller.managementClient, controller.machineInformer, controller.machineResource, machine); err != nil {
+				t.Fatalf("unexpected error updating machine, got %v", err)
+			}
+		}
+
+		// machines that are in pending state should not be counted towards the active nodes when calculating a decrease in size.
+		if tc.includePendingMachine {
+			// because we want to allow for tests that have deleted, failed machines, and pending machine, we use the third machine in the test data.
+			if tc.initial < 3 {
+				t.Fatal("test cannot pass, pending machine requires at least 3 machine in machineset")
+			}
+
+			// Simulate a pending machine
+			machine := testConfig.machines[2].DeepCopy()
+
+			unstructured.RemoveNestedField(machine.Object, "spec", "providerID")
+			unstructured.RemoveNestedField(machine.Object, "status", "nodeRef")
+
+			if err := updateResource(controller.managementClient, controller.machineInformer, controller.machineResource, machine); err != nil {
+				t.Fatalf("unexpected error updating machine, got %v", err)
+			}
+		}
 
 		nodegroups, err := controller.nodeGroups()
 		if err != nil {
@@ -510,45 +565,83 @@ func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 		}
 	}
 
-	annotations := map[string]string{
-		nodeGroupMinSizeAnnotationKey: "1",
-		nodeGroupMaxSizeAnnotationKey: "10",
-	}
-
-	t.Run("MachineSet", func(t *testing.T) {
-		tc := testCase{
+	testCases := []testCase{
+		{
 			description:         "Same number of existing instances and node group target size should error",
 			initial:             3,
 			targetSizeIncrement: 0,
 			expected:            3,
 			delta:               -1,
 			expectedError:       true,
-		}
-		test(t, &tc, createMachineSetTestConfig(RandomString(6), RandomString(6), RandomString(6), int(tc.initial), annotations, nil))
-	})
-
-	t.Run("MachineSet", func(t *testing.T) {
-		tc := testCase{
+		},
+		{
 			description:         "A node group with target size 4 but only 3 existing instances should decrease by 1",
 			initial:             3,
 			targetSizeIncrement: 1,
 			expected:            3,
 			delta:               -1,
-		}
-		test(t, &tc, createMachineSetTestConfig(RandomString(6), RandomString(6), RandomString(6), int(tc.initial), annotations, nil))
-	})
+		},
+		{
+			description:            "A node group with 4 replicas with one machine in deleting state should decrease by 1",
+			initial:                4,
+			targetSizeIncrement:    0,
+			expected:               3,
+			delta:                  -1,
+			includeDeletingMachine: true,
+		},
+		{
+			description:          "A node group with 4 replicas with one failed machine should decrease by 1",
+			initial:              4,
+			targetSizeIncrement:  0,
+			expected:             3,
+			delta:                -1,
+			includeFailedMachine: true,
+		},
+		{
+			description:           "A node group with 4 replicas with one pending machine should decrease by 1",
+			initial:               4,
+			targetSizeIncrement:   0,
+			expected:              3,
+			delta:                 -1,
+			includePendingMachine: true,
+		},
+		{
+			description:           "A node group with 5 replicas with one pending and one failed machine should decrease by 2",
+			initial:               5,
+			targetSizeIncrement:   0,
+			expected:              3,
+			delta:                 -2,
+			includeFailedMachine:  true,
+			includePendingMachine: true,
+		},
+		{
+			description:            "A node group with 5 replicas with one pending, one failed, and one deleting machine should decrease by 3",
+			initial:                5,
+			targetSizeIncrement:    0,
+			expected:               2,
+			delta:                  -3,
+			includeFailedMachine:   true,
+			includePendingMachine:  true,
+			includeDeletingMachine: true,
+		},
+	}
 
-	t.Run("MachineDeployment", func(t *testing.T) {
-		tc := testCase{
-			description:         "Same number of existing instances and node group target size should error",
-			initial:             3,
-			targetSizeIncrement: 0,
-			expected:            3,
-			delta:               -1,
-			expectedError:       true,
-		}
-		test(t, &tc, createMachineDeploymentTestConfig(RandomString(6), RandomString(6), RandomString(6), int(tc.initial), annotations, nil))
-	})
+	annotations := map[string]string{
+		nodeGroupMinSizeAnnotationKey: "1",
+		nodeGroupMaxSizeAnnotationKey: "10",
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			test(t, &tc, createMachineSetTestConfig(RandomString(6), RandomString(6), RandomString(6), int(tc.initial), annotations, nil))
+		})
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			test(t, &tc, createMachineDeploymentTestConfig(RandomString(6), RandomString(6), RandomString(6), int(tc.initial), annotations, nil))
+		})
+	}
 }
 
 func TestNodeGroupDecreaseSizeErrors(t *testing.T) {
@@ -568,7 +661,7 @@ func TestNodeGroupDecreaseSizeErrors(t *testing.T) {
 		description: "errors because initial+delta < len(nodes)",
 		delta:       -1,
 		initial:     3,
-		errorMsg:    "attempt to delete existing nodes targetSize:3 delta:-1 existingNodes: 3",
+		errorMsg:    "attempt to delete existing nodes currentReplicas:3 delta:-1 existingNodes: 3",
 	}}
 
 	test := func(t *testing.T, tc *testCase, testConfig *testConfig) {

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -1673,3 +1673,223 @@ func TestNodeGroupTemplateNodeInfo(t *testing.T) {
 	}
 
 }
+
+func TestNodeGroupNodesInstancesStatus(t *testing.T) {
+	type testCase struct {
+		description                        string
+		nodeCount                          int
+		includePendingMachine              bool
+		includeDeletingMachine             bool
+		includeFailedMachineWithNodeRef    bool
+		includeFailedMachineWithoutNodeRef bool
+		includeFailedMachineDeleting       bool
+	}
+
+	testCases := []testCase{
+		{
+			description: "standard number of nodes",
+			nodeCount:   5,
+		},
+		{
+			description:           "includes a machine in pending state",
+			nodeCount:             5,
+			includePendingMachine: true,
+		},
+		{
+			description:            "includes a machine in deleting state",
+			nodeCount:              5,
+			includeDeletingMachine: true,
+		},
+		{
+			description:                     "includes a machine in failed state with nodeRef",
+			nodeCount:                       5,
+			includeFailedMachineWithNodeRef: true,
+		},
+		{
+			description:                        "includes a machine in failed state without nodeRef",
+			nodeCount:                          5,
+			includeFailedMachineWithoutNodeRef: true,
+		},
+	}
+
+	test := func(t *testing.T, tc *testCase, testConfig *testConfig) {
+		controller, stop := mustCreateTestController(t, testConfig)
+		defer stop()
+
+		if tc.includePendingMachine {
+			if tc.nodeCount < 1 {
+				t.Fatal("test cannot pass, deleted machine requires at least 1 machine in machineset")
+			}
+
+			machine := testConfig.machines[0].DeepCopy()
+			unstructured.RemoveNestedField(machine.Object, "spec", "providerID")
+			unstructured.RemoveNestedField(machine.Object, "status", "nodeRef")
+
+			if err := updateResource(controller.managementClient, controller.machineInformer, controller.machineResource, machine); err != nil {
+				t.Fatalf("unexpected error updating machine, got %v", err)
+			}
+		}
+
+		if tc.includeDeletingMachine {
+			if tc.nodeCount < 2 {
+				t.Fatal("test cannot pass, deleted machine requires at least 2 machine in machineset")
+			}
+
+			machine := testConfig.machines[1].DeepCopy()
+			timestamp := metav1.Now()
+			machine.SetDeletionTimestamp(&timestamp)
+
+			if err := updateResource(controller.managementClient, controller.machineInformer, controller.machineResource, machine); err != nil {
+				t.Fatalf("unexpected error updating machine, got %v", err)
+			}
+		}
+
+		if tc.includeFailedMachineWithNodeRef {
+			if tc.nodeCount < 3 {
+				t.Fatal("test cannot pass, deleted machine requires at least 3 machine in machineset")
+			}
+
+			machine := testConfig.machines[2].DeepCopy()
+			unstructured.SetNestedField(machine.Object, "node-1", "status", "nodeRef", "name")
+			unstructured.SetNestedField(machine.Object, "ErrorMessage", "status", "errorMessage")
+
+			if err := updateResource(controller.managementClient, controller.machineInformer, controller.machineResource, machine); err != nil {
+				t.Fatalf("unexpected error updating machine, got %v", err)
+			}
+		}
+
+		if tc.includeFailedMachineWithoutNodeRef {
+			if tc.nodeCount < 4 {
+				t.Fatal("test cannot pass, deleted machine requires at least 4 machine in machineset")
+			}
+
+			machine := testConfig.machines[3].DeepCopy()
+			unstructured.RemoveNestedField(machine.Object, "status", "nodeRef")
+			unstructured.SetNestedField(machine.Object, "ErrorMessage", "status", "errorMessage")
+
+			if err := updateResource(controller.managementClient, controller.machineInformer, controller.machineResource, machine); err != nil {
+				t.Fatalf("unexpected error updating machine, got %v", err)
+			}
+		}
+
+		if tc.includeFailedMachineDeleting {
+			if tc.nodeCount < 5 {
+				t.Fatal("test cannot pass, deleted machine requires at least 5 machine in machineset")
+			}
+
+			machine := testConfig.machines[4].DeepCopy()
+			timestamp := metav1.Now()
+			machine.SetDeletionTimestamp(&timestamp)
+			unstructured.SetNestedField(machine.Object, "ErrorMessage", "status", "errorMessage")
+
+			if err := updateResource(controller.managementClient, controller.machineInformer, controller.machineResource, machine); err != nil {
+				t.Fatalf("unexpected error updating machine, got %v", err)
+			}
+		}
+
+		nodegroups, err := controller.nodeGroups()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if l := len(nodegroups); l != 1 {
+			t.Fatalf("expected 1 nodegroup, got %d", l)
+		}
+
+		ng := nodegroups[0]
+		instances, err := ng.Nodes()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		expectedCount := tc.nodeCount
+		if len(instances) != expectedCount {
+			t.Errorf("expected %d nodes, got %d", expectedCount, len(instances))
+		}
+
+		// Sort instances by Id for stable comparison
+		sort.Slice(instances, func(i, j int) bool {
+			return instances[i].Id < instances[j].Id
+		})
+
+		for _, instance := range instances {
+			t.Logf("instance: %v", instance)
+			if tc.includePendingMachine && strings.HasPrefix(instance.Id, pendingMachinePrefix) {
+				if instance.Status == nil || instance.Status.State != cloudprovider.InstanceCreating {
+					t.Errorf("expected pending machine to have status %v, got %v", cloudprovider.InstanceCreating, instance.Status)
+				}
+			} else if tc.includeDeletingMachine && strings.HasPrefix(instance.Id, deletingMachinePrefix) {
+				if instance.Status == nil || instance.Status.State != cloudprovider.InstanceDeleting {
+					t.Errorf("expected deleting machine to have status %v, got %v", cloudprovider.InstanceDeleting, instance.Status)
+				}
+			} else if tc.includeFailedMachineWithNodeRef && strings.HasPrefix(instance.Id, failedMachinePrefix) {
+				if instance.Status != nil {
+					t.Errorf("expected failed machine with nodeRef to not have status, got %v", instance.Status)
+				}
+			} else if tc.includeFailedMachineWithoutNodeRef && strings.HasPrefix(instance.Id, failedMachinePrefix) {
+				if instance.Status == nil || instance.Status.State != cloudprovider.InstanceCreating {
+					t.Errorf("expected failed machine without nodeRef to have status %v, got %v", cloudprovider.InstanceCreating, instance.Status)
+				}
+				if instance.Status == nil || instance.Status.ErrorInfo.ErrorClass != cloudprovider.OtherErrorClass {
+					t.Errorf("expected failed machine without nodeRef to have error class %v, got %v", cloudprovider.OtherErrorClass, instance.Status.ErrorInfo.ErrorClass)
+				}
+				if instance.Status == nil || instance.Status.ErrorInfo.ErrorCode != "ProvisioningFailed" {
+					t.Errorf("expected failed machine without nodeRef to have error code %v, got %v", "ProvisioningFailed", instance.Status.ErrorInfo.ErrorCode)
+				}
+			} else if tc.includeFailedMachineDeleting && strings.HasPrefix(instance.Id, failedMachinePrefix) {
+				if instance.Status == nil || instance.Status.State != cloudprovider.InstanceDeleting {
+					t.Errorf("expected failed machine deleting to have status %v, got %v", cloudprovider.InstanceDeleting, instance.Status)
+				}
+				if instance.Status == nil || instance.Status.ErrorInfo.ErrorClass != cloudprovider.OtherErrorClass {
+					t.Errorf("expected failed machine deleting to have error class %v, got %v", cloudprovider.OtherErrorClass, instance.Status.ErrorInfo.ErrorClass)
+				}
+				if instance.Status == nil || instance.Status.ErrorInfo.ErrorCode != "DeletingFailed" {
+					t.Errorf("expected failed machine deleting to have error code %v, got %v", "DeletingFailed", instance.Status.ErrorInfo.ErrorCode)
+				}
+			}
+		}
+	}
+
+	annotations := map[string]string{
+		nodeGroupMinSizeAnnotationKey: "1",
+		nodeGroupMaxSizeAnnotationKey: "10",
+	}
+
+	t.Run("MachineSet", func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.description, func(t *testing.T) {
+				test(
+					t,
+					&tc,
+					createMachineSetTestConfig(
+						RandomString(6),
+						RandomString(6),
+						RandomString(6),
+						tc.nodeCount,
+						annotations,
+						nil,
+					),
+				)
+			})
+		}
+	})
+
+	t.Run("MachineDeployment", func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.description, func(t *testing.T) {
+				test(
+					t,
+					&tc,
+					createMachineDeploymentTestConfig(
+						RandomString(6),
+						RandomString(6),
+						RandomString(6),
+						tc.nodeCount,
+						annotations,
+						nil,
+					),
+				)
+			})
+		}
+	})
+}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -394,16 +394,18 @@ func TestNodeGroupIncreaseSize(t *testing.T) {
 
 func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 	type testCase struct {
-		description                        string
-		delta                              int
-		initial                            int32
-		targetSizeIncrement                int32
-		expected                           int32
-		expectedError                      bool
-		includeDeletingMachine             bool
-		includeFailedMachine               bool
-		includeFailedMachineWithProviderID bool
-		includePendingMachine              bool
+		description                         string
+		delta                               int
+		initial                             int32
+		targetSizeIncrement                 int32
+		expected                            int32
+		expectedError                       bool
+		includeDeletingMachine              bool
+		includeFailedMachine                bool
+		includeFailedMachineWithProviderID  bool
+		includePendingMachine               bool
+		includePendingMachineWithProviderID bool
+		machinesDoNotHaveProviderIDs        bool
 	}
 
 	test := func(t *testing.T, tc *testCase, testConfig *testConfig) {
@@ -456,11 +458,24 @@ func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 			// Simulate a pending machine
 			machine := testConfig.machines[2].DeepCopy()
 
-			unstructured.RemoveNestedField(machine.Object, "spec", "providerID")
+			if !tc.includePendingMachineWithProviderID {
+				unstructured.RemoveNestedField(machine.Object, "spec", "providerID")
+			}
 			unstructured.RemoveNestedField(machine.Object, "status", "nodeRef")
 
 			if err := updateResource(controller.managementClient, controller.machineInformer, controller.machineResource, machine); err != nil {
 				t.Fatalf("unexpected error updating machine, got %v", err)
+			}
+		}
+
+		// machines with no provider id can be created on some providers, notably bare metal
+		if tc.machinesDoNotHaveProviderIDs {
+			for _, machine := range testConfig.machines {
+				updated := machine.DeepCopy()
+				unstructured.RemoveNestedField(updated.Object, "spec", "providerID")
+				if err := updateResource(controller.managementClient, controller.machineInformer, controller.machineResource, updated); err != nil {
+					t.Fatalf("unexpected error updating machine, got %v", err)
+				}
 			}
 		}
 
@@ -635,6 +650,23 @@ func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 			delta:                              -1,
 			includeFailedMachine:               true,
 			includeFailedMachineWithProviderID: true,
+		},
+		{
+			description:                         "A node group with 4 replicas with one pending machine that has a provider ID should decrease by 1",
+			initial:                             4,
+			targetSizeIncrement:                 0,
+			expected:                            3,
+			delta:                               -1,
+			includePendingMachine:               true,
+			includePendingMachineWithProviderID: true,
+		},
+		{
+			description:                  "A node group with target size 4 but only 3 existing instances without provider IDs should decrease by 1",
+			initial:                      3,
+			targetSizeIncrement:          1,
+			expected:                     3,
+			delta:                        -1,
+			machinesDoNotHaveProviderIDs: true,
 		},
 	}
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -18,6 +18,7 @@ package clusterapi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path"
 	"strings"
@@ -94,6 +95,13 @@ func (r unstructuredScalableResource) Replicas() (int, error) {
 		return 0, err
 	}
 
+	// this function needs to differentiate between machine-api and cluster-api
+	// due to the fact that the machine-api controllers exclude machines in
+	// deleting phase when calculating replicas.
+	if gvr.Group == openshiftMAPIGroup {
+		return r.replicasOpenshift()
+	}
+
 	s, err := r.controller.managementScaleClient.Scales(r.Namespace()).Get(context.TODO(), gvr.GroupResource(), r.Name(), metav1.GetOptions{})
 	if err != nil {
 		return 0, err
@@ -103,6 +111,59 @@ func (r unstructuredScalableResource) Replicas() (int, error) {
 		return 0, fmt.Errorf("failed to fetch resource scale: unknown %s %s/%s", r.Kind(), r.Namespace(), r.Name())
 	}
 	return int(s.Spec.Replicas), nil
+}
+
+func (r unstructuredScalableResource) replicasOpenshift() (int, error) {
+	gvr, err := r.GroupVersionResource()
+	if err != nil {
+		return 0, fmt.Errorf("error getting GVR in replicasOpenshift: %w", err)
+	}
+
+	if gvr.Group != openshiftMAPIGroup {
+		return 0, fmt.Errorf("incorrect group for replica count on %s %s/%s", r.Kind(), r.Namespace(), r.Name())
+	}
+
+	// get the selector labels from the scalable resource to find the machines
+	rawSelector, found, err := unstructured.NestedMap(r.unstructured.Object, "spec", "selector")
+	if !found || err != nil {
+		return 0, fmt.Errorf("error getting selector in replicasOpenshift: %w", err)
+	}
+
+	// we want to massage the unstructured selector data into a LabelSelector struct
+	// so that we can more easily create the necessary string for the ListOptions struct,
+	// the following code helps with that.
+	data, err := json.Marshal(rawSelector)
+	if err != nil {
+		return 0, fmt.Errorf("error marshaling selector in replicasOpenshift: %w", err)
+	}
+
+	var labelSelector metav1.LabelSelector
+	if err := json.Unmarshal(data, &labelSelector); err != nil {
+		return 0, fmt.Errorf("error unmarshaling selector in replicasOpenshift: %w", err)
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(&labelSelector)
+	if err != nil {
+		return 0, fmt.Errorf("error seting label selector in replicasOpenshift: %w", err)
+	}
+
+	// get a list of machines filtered by the namespace and the selector labels from the scalable resource
+	machinesList, err := r.controller.managementClient.Resource(r.controller.machineResource).Namespace(r.Namespace()).List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return 0, fmt.Errorf("error listing machines in replicasOpenshift: %w", err)
+	}
+
+	// filter out inactive machines
+	var activeMachines []unstructured.Unstructured
+	for _, item := range machinesList.Items {
+		if metav1.GetControllerOf(&item) != nil && !metav1.IsControlledBy(&item, r.unstructured) {
+			continue
+		}
+
+		activeMachines = append(activeMachines, item)
+	}
+
+	return len(activeMachines), nil
 }
 
 func (r unstructuredScalableResource) SetSize(nreplicas int) error {

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
@@ -116,12 +116,32 @@ func TestSetSize(t *testing.T) {
 }
 
 func TestReplicas(t *testing.T) {
-	initialReplicas := 1
-	updatedReplicas := 5
+	type testCase struct {
+		description            string
+		initialReplicas        int
+		updatedReplicas        int
+		expectedReplicas       int
+		includeDeletingMachine bool
+	}
 
-	test := func(t *testing.T, testConfig *testConfig) {
+	test := func(t *testing.T, tc testCase, testConfig *testConfig) {
 		controller, stop := mustCreateTestController(t, testConfig)
 		defer stop()
+
+		// machines in deleting phase should be included in the replicas count
+		if tc.includeDeletingMachine {
+			if tc.initialReplicas < 1 {
+				t.Fatal("test cannot pass, deleted machine requires at least 1 machine")
+			}
+
+			machine := testConfig.machines[0].DeepCopy()
+			timestamp := metav1.Now()
+			machine.SetDeletionTimestamp(&timestamp)
+
+			if err := updateResource(controller.managementClient, controller.machineInformer, controller.machineResource, machine); err != nil {
+				t.Fatalf("unexpected error updating machine, got %v", err)
+			}
+		}
 
 		testResource := testConfig.machineSet
 		if testConfig.machineDeployment != nil {
@@ -143,8 +163,8 @@ func TestReplicas(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if i != initialReplicas {
-			t.Errorf("expected %v, got: %v", initialReplicas, i)
+		if i != tc.initialReplicas {
+			t.Errorf("expected %v, got: %v", tc.initialReplicas, i)
 		}
 
 		// fetch and update machineSet
@@ -154,7 +174,7 @@ func TestReplicas(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		s.Spec.Replicas = int32(updatedReplicas)
+		s.Spec.Replicas = int32(tc.updatedReplicas)
 
 		ch := make(chan error)
 		checkDone := func(obj interface{}) (bool, error) {
@@ -170,8 +190,8 @@ func TestReplicas(t *testing.T) {
 			if err != nil {
 				return true, err
 			}
-			if i != updatedReplicas {
-				return true, fmt.Errorf("expected %v, got: %v", updatedReplicas, i)
+			if i != tc.expectedReplicas {
+				return true, fmt.Errorf("expected %v, got: %v", tc.expectedReplicas, i)
 			}
 			return true, nil
 		}
@@ -214,13 +234,33 @@ func TestReplicas(t *testing.T) {
 		}
 	}
 
-	t.Run("MachineSet", func(t *testing.T) {
-		test(t, createMachineSetTestConfig(RandomString(6), RandomString(6), RandomString(6), initialReplicas, nil, nil))
-	})
+	testCases := []testCase{
+		{
+			description:      "starting with 1 replica and increasing to 5 replicas should return 5 replicas",
+			initialReplicas:  1,
+			updatedReplicas:  5,
+			expectedReplicas: 5,
+		},
+		{
+			description:            "starting with 1 replica and a machine in deleting and increasing to 5 replicas should return 5 replicas",
+			initialReplicas:        1,
+			updatedReplicas:        5,
+			expectedReplicas:       5,
+			includeDeletingMachine: true,
+		},
+	}
 
-	t.Run("MachineDeployment", func(t *testing.T) {
-		test(t, createMachineDeploymentTestConfig(RandomString(6), RandomString(6), RandomString(6), initialReplicas, nil, nil))
-	})
+	for _, tc := range testCases {
+		t.Run("MachineSet", func(t *testing.T) {
+			test(t, tc, createMachineSetTestConfig(RandomString(6), RandomString(6), RandomString(6), tc.initialReplicas, nil, nil))
+		})
+	}
+
+	for _, tc := range testCases {
+		t.Run("MachineDeployment", func(t *testing.T) {
+			test(t, tc, createMachineDeploymentTestConfig(RandomString(6), RandomString(6), RandomString(6), tc.initialReplicas, nil, nil))
+		})
+	}
 }
 
 func TestTaints(t *testing.T) {


### PR DESCRIPTION
this is a backport of #278, #343, #347, and #349 combined into a single PR to make things easier.
