### PR TITLE
NO-JIRA: add logging for failed node balancing

### DIFF
--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -462,6 +462,17 @@ func (o *ScaleUpOrchestrator) ComputeExpansionOption(
 	}
 
 	option.SimilarNodeGroups = o.ComputeSimilarNodeGroups(nodeGroup, nodeInfos, schedulablePodGroups, now)
+	if option.SimilarNodeGroups != nil {
+		// if similar node groups are found, log about them
+		similarNodeGroupIds := make([]string, 0)
+		for _, sng := range option.SimilarNodeGroups {
+			similarNodeGroupIds = append(similarNodeGroupIds, sng.Id())
+		}
+		klog.V(5).Infof("Found %d similar node groups: %v", len(option.SimilarNodeGroups), similarNodeGroupIds)
+	} else if o.autoscalingContext.BalanceSimilarNodeGroups {
+		// if no similar node groups are found and the flag is enabled, log about it
+		klog.V(5).Info("No similar node groups found")
+	}
 
 	estimateStart := time.Now()
 	expansionEstimator := o.estimatorBuilder(


### PR DESCRIPTION
this change adds debug logs at level 5 to aid in triaging failed node balancing. It adds logs to help determine why two node groups are not considered as similar. These logs can be quite noisy so the logging level has been set to 5 by default.