### PR TITLE
AUTOSCALE-284: Rename Cluster Autoscaler component in OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -15,5 +15,4 @@ reviewers:
 - racheljpg
 - sub-mod
 - theobarberbany
-component: Cloud Compute
-subcomponent: Cluster Autoscaler
+component: Cluster Autoscaler


### PR DESCRIPTION
Removes the subcomponent in the OWNERS file and changes the component to `Cluster Autoscaler` to reflect the current changes in moving cluster-autoscaler to autoscale team.