### PR TITLE
[release-4.18] OCPBUGS-60908: revert openshift replica fix

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -47,7 +47,6 @@ const (
 	machinePoolProviderIDIndex = "machinePoolProviderIDIndex"
 	nodeProviderIDIndex        = "nodeProviderIDIndex"
 	defaultCAPIGroup           = "cluster.x-k8s.io"
-	openshiftMAPIGroup         = "machine.openshift.io"
 	// CAPIGroupEnvVar contains the environment variable name which allows overriding defaultCAPIGroup.
 	CAPIGroupEnvVar = "CAPI_GROUP"
 	// CAPIVersionEnvVar contains the environment variable name which allows overriding the Cluster API group version.

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -18,7 +18,6 @@ package clusterapi
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"path"
 	"strings"
@@ -96,13 +95,6 @@ func (r unstructuredScalableResource) Replicas() (int, error) {
 		return 0, err
 	}
 
-	// this function needs to differentiate between machine-api and cluster-api
-	// due to the fact that the machine-api controllers exclude machines in
-	// deleting phase when calculating replicas.
-	if gvr.Group == openshiftMAPIGroup {
-		return r.replicasOpenshift()
-	}
-
 	s, err := r.controller.managementScaleClient.Scales(r.Namespace()).Get(context.TODO(), gvr.GroupResource(), r.Name(), metav1.GetOptions{})
 	if err != nil {
 		return 0, err
@@ -112,59 +104,6 @@ func (r unstructuredScalableResource) Replicas() (int, error) {
 		return 0, fmt.Errorf("failed to fetch resource scale: unknown %s %s/%s", r.Kind(), r.Namespace(), r.Name())
 	}
 	return int(s.Spec.Replicas), nil
-}
-
-func (r unstructuredScalableResource) replicasOpenshift() (int, error) {
-	gvr, err := r.GroupVersionResource()
-	if err != nil {
-		return 0, fmt.Errorf("error getting GVR in replicasOpenshift: %w", err)
-	}
-
-	if gvr.Group != openshiftMAPIGroup {
-		return 0, fmt.Errorf("incorrect group for replica count on %s %s/%s", r.Kind(), r.Namespace(), r.Name())
-	}
-
-	// get the selector labels from the scalable resource to find the machines
-	rawSelector, found, err := unstructured.NestedMap(r.unstructured.Object, "spec", "selector")
-	if !found || err != nil {
-		return 0, fmt.Errorf("error getting selector in replicasOpenshift: %w", err)
-	}
-
-	// we want to massage the unstructured selector data into a LabelSelector struct
-	// so that we can more easily create the necessary string for the ListOptions struct,
-	// the following code helps with that.
-	data, err := json.Marshal(rawSelector)
-	if err != nil {
-		return 0, fmt.Errorf("error marshaling selector in replicasOpenshift: %w", err)
-	}
-
-	var labelSelector metav1.LabelSelector
-	if err := json.Unmarshal(data, &labelSelector); err != nil {
-		return 0, fmt.Errorf("error unmarshaling selector in replicasOpenshift: %w", err)
-	}
-
-	selector, err := metav1.LabelSelectorAsSelector(&labelSelector)
-	if err != nil {
-		return 0, fmt.Errorf("error seting label selector in replicasOpenshift: %w", err)
-	}
-
-	// get a list of machines filtered by the namespace and the selector labels from the scalable resource
-	machinesList, err := r.controller.managementClient.Resource(r.controller.machineResource).Namespace(r.Namespace()).List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
-	if err != nil {
-		return 0, fmt.Errorf("error listing machines in replicasOpenshift: %w", err)
-	}
-
-	// filter out inactive machines
-	var activeMachines []unstructured.Unstructured
-	for _, item := range machinesList.Items {
-		if metav1.GetControllerOf(&item) != nil && !metav1.IsControlledBy(&item, r.unstructured) {
-			continue
-		}
-
-		activeMachines = append(activeMachines, item)
-	}
-
-	return len(activeMachines), nil
 }
 
 func (r unstructuredScalableResource) SetSize(nreplicas int) error {

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured_test.go
@@ -116,32 +116,12 @@ func TestSetSize(t *testing.T) {
 }
 
 func TestReplicas(t *testing.T) {
-	type testCase struct {
-		description            string
-		initialReplicas        int
-		updatedReplicas        int
-		expectedReplicas       int
-		includeDeletingMachine bool
-	}
+	initialReplicas := 1
+	updatedReplicas := 5
 
-	test := func(t *testing.T, tc testCase, testConfig *testConfig) {
+	test := func(t *testing.T, testConfig *testConfig) {
 		controller, stop := mustCreateTestController(t, testConfig)
 		defer stop()
-
-		// machines in deleting phase should be included in the replicas count
-		if tc.includeDeletingMachine {
-			if tc.initialReplicas < 1 {
-				t.Fatal("test cannot pass, deleted machine requires at least 1 machine")
-			}
-
-			machine := testConfig.machines[0].DeepCopy()
-			timestamp := metav1.Now()
-			machine.SetDeletionTimestamp(&timestamp)
-
-			if err := updateResource(controller.managementClient, controller.machineInformer, controller.machineResource, machine); err != nil {
-				t.Fatalf("unexpected error updating machine, got %v", err)
-			}
-		}
 
 		testResource := testConfig.machineSet
 		if testConfig.machineDeployment != nil {
@@ -163,8 +143,8 @@ func TestReplicas(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if i != tc.initialReplicas {
-			t.Errorf("expected %v, got: %v", tc.initialReplicas, i)
+		if i != initialReplicas {
+			t.Errorf("expected %v, got: %v", initialReplicas, i)
 		}
 
 		// fetch and update machineSet
@@ -174,7 +154,7 @@ func TestReplicas(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		s.Spec.Replicas = int32(tc.updatedReplicas)
+		s.Spec.Replicas = int32(updatedReplicas)
 
 		ch := make(chan error)
 		checkDone := func(obj interface{}) (bool, error) {
@@ -190,8 +170,8 @@ func TestReplicas(t *testing.T) {
 			if err != nil {
 				return true, err
 			}
-			if i != tc.expectedReplicas {
-				return true, fmt.Errorf("expected %v, got: %v", tc.expectedReplicas, i)
+			if i != updatedReplicas {
+				return true, fmt.Errorf("expected %v, got: %v", updatedReplicas, i)
 			}
 			return true, nil
 		}
@@ -234,33 +214,13 @@ func TestReplicas(t *testing.T) {
 		}
 	}
 
-	testCases := []testCase{
-		{
-			description:      "starting with 1 replica and increasing to 5 replicas should return 5 replicas",
-			initialReplicas:  1,
-			updatedReplicas:  5,
-			expectedReplicas: 5,
-		},
-		{
-			description:            "starting with 1 replica and a machine in deleting and increasing to 5 replicas should return 5 replicas",
-			initialReplicas:        1,
-			updatedReplicas:        5,
-			expectedReplicas:       5,
-			includeDeletingMachine: true,
-		},
-	}
+	t.Run("MachineSet", func(t *testing.T) {
+		test(t, createMachineSetTestConfig(RandomString(6), RandomString(6), RandomString(6), initialReplicas, nil, nil))
+	})
 
-	for _, tc := range testCases {
-		t.Run("MachineSet", func(t *testing.T) {
-			test(t, tc, createMachineSetTestConfig(RandomString(6), RandomString(6), RandomString(6), tc.initialReplicas, nil, nil))
-		})
-	}
-
-	for _, tc := range testCases {
-		t.Run("MachineDeployment", func(t *testing.T) {
-			test(t, tc, createMachineDeploymentTestConfig(RandomString(6), RandomString(6), RandomString(6), tc.initialReplicas, nil, nil))
-		})
-	}
+	t.Run("MachineDeployment", func(t *testing.T) {
+		test(t, createMachineDeploymentTestConfig(RandomString(6), RandomString(6), RandomString(6), initialReplicas, nil, nil))
+	})
 }
 
 func TestTaints(t *testing.T) {


### PR DESCRIPTION
this change reverts the fix from PR 278 that attempted to make the replica counting more accurate for openshift. It is being reverted due to a failure in our test verification that gave a false positive on improving the counting.

this commit, and the related commit from PR 278 should be dropped on the next kubernetes rebase.
