### PR TITLE
OCPBUGS-60790: refactor cloud provider options

### DIFF
--- a/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/alicloud/alicloud_cloud_provider.go
@@ -24,8 +24,8 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	klog "k8s.io/klog/v2"
@@ -220,7 +220,7 @@ func buildAsg(manager *AliCloudManager, minSize int, maxSize int, id string, reg
 }
 
 // BuildAlicloud returns alicloud provider
-func BuildAlicloud(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func BuildAlicloud(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	var aliManager *AliCloudManager
 	var aliError error
 	if opts.CloudConfig != "" {

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
@@ -415,7 +416,7 @@ func (ng *AwsNodeGroup) TemplateNodeInfo() (*framework.NodeInfo, error) {
 }
 
 // BuildAWS builds AWS cloud provider, manager etc.
-func BuildAWS(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func BuildAWS(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	var cfg io.ReadCloser
 	if opts.CloudConfig != "" {
 		var err error

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/aws"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws/aws-sdk-go/service/autoscaling"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 )
 
 var testAwsManager = &AwsManager{
@@ -133,7 +133,7 @@ func TestInstanceTypeFallback(t *testing.T) {
 		map[string]int64{cloudprovider.ResourceNameCores: 10, cloudprovider.ResourceNameMemory: 100000000})
 
 	do := cloudprovider.NodeGroupDiscoveryOptions{}
-	opts := config.AutoscalingOptions{}
+	opts := &coreoptions.AutoscalerOptions{}
 
 	t.Setenv("AWS_REGION", "non-existent-region")
 

--- a/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go
@@ -25,7 +25,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	klog "k8s.io/klog/v2"
@@ -190,7 +190,7 @@ func (m *azureRef) String() string {
 }
 
 // BuildAzure builds Azure cloud provider, manager etc.
-func BuildAzure(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func BuildAzure(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	var config io.ReadCloser
 	if opts.CloudConfig != "" {
 		klog.Infof("Creating Azure Manager using cloud-config file: %v", opts.CloudConfig)

--- a/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/baiducloud/baiducloud_cloud_provider.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
@@ -56,7 +57,7 @@ type baiducloudCloudProvider struct {
 }
 
 // BuildBaiducloud builds baiducloud cloud provider, manager etc.
-func BuildBaiducloud(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func BuildBaiducloud(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	var cfg io.ReadCloser
 	if opts.CloudConfig != "" {
 		var err error

--- a/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/bizflycloud/bizflycloud_cloud_provider.go
@@ -25,7 +25,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	klog "k8s.io/klog/v2"
@@ -174,7 +174,7 @@ func (d *bizflycloudCloudProvider) Refresh() error {
 
 // BuildBizflyCloud builds the Bizflycloud cloud provider.
 func BuildBizflyCloud(
-	opts config.AutoscalingOptions,
+	opts *coreoptions.AutoscalerOptions,
 	do cloudprovider.NodeGroupDiscoveryOptions,
 	rl *cloudprovider.ResourceLimiter,
 ) cloudprovider.CloudProvider {

--- a/cluster-autoscaler/cloudprovider/brightbox/brightbox_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/brightbox/brightbox_cloud_provider.go
@@ -28,7 +28,7 @@ import (
 	brightbox "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/brightbox/gobrightbox"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/brightbox/gobrightbox/status"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/brightbox/k8ssdk"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	klog "k8s.io/klog/v2"
@@ -221,7 +221,7 @@ func (b *brightboxCloudProvider) Cleanup() error {
 
 // BuildBrightbox builds the Brightbox provider
 func BuildBrightbox(
-	opts config.AutoscalingOptions,
+	opts *coreoptions.AutoscalerOptions,
 	do cloudprovider.NodeGroupDiscoveryOptions,
 	rl *cloudprovider.ResourceLimiter,
 ) cloudprovider.CloudProvider {

--- a/cluster-autoscaler/cloudprovider/brightbox/brightbox_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/brightbox/brightbox_cloud_provider_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/brightbox/k8ssdk"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/brightbox/k8ssdk/mocks"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	klog "k8s.io/klog/v2"
 )
 
@@ -138,9 +139,11 @@ func TestBuildBrightBox(t *testing.T) {
 	defer ts.Close()
 	rl := cloudprovider.NewResourceLimiter(nil, nil)
 	do := cloudprovider.NodeGroupDiscoveryOptions{}
-	opts := config.AutoscalingOptions{
-		CloudProviderName: cloudprovider.BrightboxProviderName,
-		ClusterName:       fakeClusterName,
+	opts := &coreoptions.AutoscalerOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
+			CloudProviderName: cloudprovider.BrightboxProviderName,
+			ClusterName:       fakeClusterName,
+		},
 	}
 	cloud := BuildBrightbox(opts, do, rl)
 	assert.Equal(t, cloud.Name(), cloudprovider.BrightboxProviderName)
@@ -170,8 +173,10 @@ func TestBuildBrightboxMissingClusterName(t *testing.T) {
 		defer ts.Close()
 		rl := cloudprovider.NewResourceLimiter(nil, nil)
 		do := cloudprovider.NodeGroupDiscoveryOptions{}
-		opts := config.AutoscalingOptions{
-			CloudProviderName: cloudprovider.BrightboxProviderName,
+		opts := &coreoptions.AutoscalerOptions{
+			AutoscalingOptions: config.AutoscalingOptions{
+				CloudProviderName: cloudprovider.BrightboxProviderName,
+			},
 		}
 		BuildBrightbox(opts, do, rl)
 	})

--- a/cluster-autoscaler/cloudprovider/builder/builder_alicloud.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_alicloud.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/alicloud"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for alicloud-only build is alicloud.
 const DefaultCloudProvider = cloudprovider.AlicloudProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.AlicloudProviderName:
 		return alicloud.BuildAlicloud(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_all.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_all.go
@@ -52,7 +52,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/utho"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/volcengine"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vultr"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -94,7 +94,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider is GCE.
 const DefaultCloudProvider = cloudprovider.GceProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions,
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions,
 	do cloudprovider.NodeGroupDiscoveryOptions,
 	rl *cloudprovider.ResourceLimiter,
 	informerFactory informers.SharedInformerFactory) cloudprovider.CloudProvider {

--- a/cluster-autoscaler/cloudprovider/builder/builder_aws.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_aws.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/aws"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for AWS-only build is AWS.
 const DefaultCloudProvider = cloudprovider.AwsProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.AwsProviderName:
 		return aws.BuildAWS(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_azure.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_azure.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/azure"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider on Azure-only build is Azure.
 const DefaultCloudProvider = cloudprovider.AzureProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.AzureProviderName:
 		return azure.BuildAzure(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_baiducloud.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_baiducloud.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/baiducloud"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for baiducloud-only build is baiducloud.
 const DefaultCloudProvider = cloudprovider.BaiducloudProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.BaiducloudProviderName:
 		return baiducloud.BuildBaiducloud(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_bizflycloud.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_bizflycloud.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/bizflycloud"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for Bizflycloud-only build is Bizflycloud.
 const DefaultCloudProvider = cloudprovider.BizflyCloudProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.BizflyCloudProviderName:
 		return bizflycloud.BuildBizflyCloud(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_brightbox.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_brightbox.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/brightbox"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for Brightbox-only build is Brightbox.
 const DefaultCloudProvider = cloudprovider.BrightboxProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.BrightboxProviderName:
 		return brightbox.BuildBrightbox(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_cherry.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_cherry.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	cherry "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/cherryservers"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for Cherry-only build is Cherry.
 const DefaultCloudProvider = cherry.ProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cherry.ProviderName:
 		return cherry.BuildCherry(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_civo.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_civo.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/civo"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for Civo-only build is Civo.
 const DefaultCloudProvider = cloudprovider.CivoProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.CivoProviderName:
 		return civo.BuildCivo(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_cloudstack.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_cloudstack.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/cloudstack"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for cloudstack-only build is cloudstack.
 const DefaultCloudProvider = cloudprovider.CloudStackProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.CloudStackProviderName:
 		return cloudstack.BuildCloudStack(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_clusterapi.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_clusterapi.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/clusterapi"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for Cluster API-only build is Cluster API.
 const DefaultCloudProvider = cloudprovider.ClusterAPIProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.ClusterAPIProviderName:
 		return clusterapi.BuildClusterAPI(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_coreweave.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_coreweave.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/coreweave"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,6 +34,6 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for coreweave-only build is coreweave.
 const DefaultCloudProvider = cloudprovider.CoreWeaveProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	return coreweave.BuildCoreWeave(opts, do, rl)
 }

--- a/cluster-autoscaler/cloudprovider/builder/builder_digitalocean.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_digitalocean.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/digitalocean"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for DigitalOcean-only build is DigitalOcean.
 const DefaultCloudProvider = cloudprovider.DigitalOceanProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.DigitalOceanProviderName:
 		return digitalocean.BuildDigitalOcean(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_equinixmetal.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_equinixmetal.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/equinixmetal"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -35,7 +35,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for Packet or Equinix Metal-only build is Equinix Metal.
 const DefaultCloudProvider = cloudprovider.EquinixMetalProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.PacketProviderName, cloudprovider.EquinixMetalProviderName:
 		return equinixmetal.BuildCloudProvider(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_exoscale.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_exoscale.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/exoscale"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for Exoscale-only build is Exoscale.
 const DefaultCloudProvider = cloudprovider.ExoscaleProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.ExoscaleProviderName:
 		return exoscale.BuildExoscale(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_externalgrpc.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_externalgrpc.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/externalgrpc"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for externalgrpc-only build is externalgrpc.
 const DefaultCloudProvider = cloudprovider.ExternalGrpcProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.ExternalGrpcProviderName:
 		return externalgrpc.BuildExternalGrpc(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_gce.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_gce.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/gce"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for GCE-only build is GCE.
 const DefaultCloudProvider = cloudprovider.GceProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.GceProviderName:
 		return gce.BuildGCE(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_hetzner.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_hetzner.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for Hetzner-only build is Hetzner.
 const DefaultCloudProvider = cloudprovider.HetznerProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.HetznerProviderName:
 		return hetzner.BuildHetzner(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_huaweicloud.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_huaweicloud.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/huaweicloud"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for huaweicloud-only build is huaweicloud.
 const DefaultCloudProvider = cloudprovider.HuaweicloudProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.HuaweicloudProviderName:
 		return huaweicloud.BuildHuaweiCloud(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_ionoscloud.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_ionoscloud.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/ionoscloud"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for IonosCloud-only build is IonosCloud.
 const DefaultCloudProvider = cloudprovider.IonoscloudProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.IonoscloudProviderName:
 		return ionoscloud.BuildIonosCloud(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_kamatera.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_kamatera.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/kamatera"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for Kamatera-only build is Kamatera.
 const DefaultCloudProvider = cloudprovider.KamateraProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.KamateraProviderName:
 		return kamatera.BuildKamatera(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_kubemark.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_kubemark.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/kubemark"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for Kubemark-only build is Kubemark.
 const DefaultCloudProvider = cloudprovider.KubemarkProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.KubemarkProviderName:
 		return kubemark.BuildKubemark(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_kwok.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_kwok.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/kwok"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 
 	"k8s.io/client-go/informers"
 )
@@ -35,7 +35,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for Kwok-only build is Kwok.
 const DefaultCloudProvider = cloudprovider.KwokProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, informerFactory informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, informerFactory informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.KwokProviderName:
 		return kwok.BuildKwok(opts, do, rl, informerFactory)

--- a/cluster-autoscaler/cloudprovider/builder/builder_linode.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_linode.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/linode"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for linode-only build is linode.
 const DefaultCloudProvider = cloudprovider.LinodeProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.LinodeProviderName:
 		return linode.BuildLinode(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_magnum.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_magnum.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for Magnum-only build is Magnum.
 const DefaultCloudProvider = cloudprovider.MagnumProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.MagnumProviderName:
 		return magnum.BuildMagnum(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_oci.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_oci.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	oci "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/instancepools"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for oci-only build is oci.
 const DefaultCloudProvider = cloudprovider.OracleCloudProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.OracleCloudProviderName:
 		return oci.BuildOCI(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_ovhcloud.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_ovhcloud.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/ovhcloud"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for OVHcloud-only build is OVHcloud.
 const DefaultCloudProvider = cloudprovider.OVHcloudProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.OVHcloudProviderName:
 		return ovhcloud.BuildOVHcloud(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_rancher.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_rancher.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/rancher"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for rancher-only build is rancher.
 const DefaultCloudProvider = cloudprovider.RancherProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.RancherProviderName:
 		return rancher.BuildRancher(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_scaleway.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_scaleway.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/scaleway"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for Scaleway-only build is Scaleway.
 const DefaultCloudProvider = cloudprovider.ScalewayProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.ScalewayProviderName:
 		return scaleway.BuildScaleway(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_tencentcloud.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_tencentcloud.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/tencentcloud"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for Tencent-only build is Tencent.
 const DefaultCloudProvider = cloudprovider.TencentcloudProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.TencentcloudProviderName:
 		return tencentcloud.BuildTencentcloud(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_utho.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_utho.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/utho"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for utho-only build is utho.
 const DefaultCloudProvider = cloudprovider.UthoProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.UthoProviderName:
 		return utho.BuildUtho(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_volcengine.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_volcengine.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/volcengine"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for volcengine-only build is volcengine.
 const DefaultCloudProvider = cloudprovider.VolcengineProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.VolcengineProviderName:
 		return volcengine.BuildVolcengine(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/builder_vultr.go
+++ b/cluster-autoscaler/cloudprovider/builder/builder_vultr.go
@@ -22,7 +22,7 @@ package builder
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/vultr"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 )
 
@@ -34,7 +34,7 @@ var AvailableCloudProviders = []string{
 // DefaultCloudProvider for vultr-only build is vultr.
 const DefaultCloudProvider = cloudprovider.VultrProviderName
 
-func buildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func buildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter, _ informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	switch opts.CloudProviderName {
 	case cloudprovider.VultrProviderName:
 		return vultr.BuildVultr(opts, do, rl)

--- a/cluster-autoscaler/cloudprovider/builder/cloud_provider_builder.go
+++ b/cluster-autoscaler/cloudprovider/builder/cloud_provider_builder.go
@@ -18,15 +18,15 @@ package builder
 
 import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
-	"k8s.io/autoscaler/cluster-autoscaler/context"
+	ca_context "k8s.io/autoscaler/cluster-autoscaler/context"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/client-go/informers"
 
 	klog "k8s.io/klog/v2"
 )
 
 // NewCloudProvider builds a cloud provider from provided parameters.
-func NewCloudProvider(opts config.AutoscalingOptions, informerFactory informers.SharedInformerFactory) cloudprovider.CloudProvider {
+func NewCloudProvider(opts *coreoptions.AutoscalerOptions, informerFactory informers.SharedInformerFactory) cloudprovider.CloudProvider {
 	klog.V(1).Infof("Building %s cloud provider.", opts.CloudProviderName)
 
 	do := cloudprovider.NodeGroupDiscoveryOptions{
@@ -34,7 +34,7 @@ func NewCloudProvider(opts config.AutoscalingOptions, informerFactory informers.
 		NodeGroupAutoDiscoverySpecs: opts.NodeGroupAutoDiscovery,
 	}
 
-	rl := context.NewResourceLimiterFromAutoscalingOptions(opts)
+	rl := ca_context.NewResourceLimiterFromAutoscalingOptions(opts.AutoscalingOptions)
 
 	if opts.CloudProviderName == "" {
 		// Ideally this would be an error, but several unit tests of the

--- a/cluster-autoscaler/cloudprovider/cherryservers/cherry_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cherryservers/cherry_cloud_provider.go
@@ -24,8 +24,8 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	klog "k8s.io/klog/v2"
@@ -174,7 +174,7 @@ func (ccp *cherryCloudProvider) Cleanup() error {
 //
 // The cherryManager is created here, and the node groups are created
 // based on the specs provided via the command line parameters.
-func BuildCherry(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func BuildCherry(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	var config io.ReadCloser
 
 	if opts.CloudConfig != "" {
@@ -186,7 +186,7 @@ func BuildCherry(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDisco
 		defer config.Close()
 	}
 
-	manager, err := createCherryManager(config, do, opts)
+	manager, err := createCherryManager(config, do, opts.AutoscalingOptions)
 	if err != nil {
 		klog.Fatalf("Failed to create cherry manager: %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/civo/civo_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/civo/civo_cloud_provider.go
@@ -25,7 +25,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	"k8s.io/klog/v2"
@@ -169,7 +169,7 @@ func (d *civoCloudProvider) Refresh() error {
 
 // BuildCivo builds the Civo cloud provider.
 func BuildCivo(
-	opts config.AutoscalingOptions,
+	opts *coreoptions.AutoscalerOptions,
 	do cloudprovider.NodeGroupDiscoveryOptions,
 	rl *cloudprovider.ResourceLimiter,
 ) cloudprovider.CloudProvider {

--- a/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/cloudstack/cloudstack_cloud_provider.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 
@@ -149,9 +150,9 @@ func createClusterConfig(opts config.AutoscalingOptions) (*clusterConfig, error)
 }
 
 // BuildCloudStack builds CloudProvider implementation for CloudStack
-func BuildCloudStack(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func BuildCloudStack(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 
-	config, err := createClusterConfig(opts)
+	config, err := createClusterConfig(opts.AutoscalingOptions)
 	if err != nil {
 		klog.Fatal(err)
 	}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go
@@ -458,6 +458,68 @@ func (ng *nodegroup) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*c
 	return &defaults, nil
 }
 
+func (ng *nodegroup) IsMachineDeploymentAndRollingOut() (bool, error) {
+	if ng.scalableResource.Kind() != machineDeploymentKind {
+		// Not a MachineDeployment.
+		return false, nil
+	}
+
+	machineSets, err := ng.machineController.listMachineSetsForMachineDeployment(ng.scalableResource.unstructured)
+	if err != nil {
+		return false, err
+	}
+
+	if len(machineSets) == 0 {
+		// No MachineSets => MD is not rolling out.
+		return false, nil
+	}
+
+	// Find the latest revision, the MachineSet with the latest revision is the MachineSet that
+	// matches the MachineDeployment spec.
+	var latestMSRevisionInt int64
+	for _, ms := range machineSets {
+		msRevision, ok := ms.GetAnnotations()[machineDeploymentRevisionAnnotation]
+		if !ok {
+			continue
+		}
+
+		msRevisionInt, err := strconv.ParseInt(msRevision, 10, 64)
+		if err != nil {
+			return false, errors.Wrapf(err, "failed to parse current revision on MachineSet %s", klog.KObj(ms))
+		}
+		latestMSRevisionInt = max(latestMSRevisionInt, msRevisionInt)
+	}
+	maxMSRevision := strconv.FormatInt(latestMSRevisionInt, 10)
+
+	for _, ms := range machineSets {
+		if ms.GetAnnotations()[machineDeploymentRevisionAnnotation] == maxMSRevision {
+			// Ignore the MachineSet with the latest revision
+			continue
+		}
+
+		// Check if any of the old MachineSets still have replicas
+		replicas, found, err := unstructured.NestedInt64(ms.UnstructuredContent(), "spec", "replicas")
+		if err != nil {
+			return false, errors.Wrapf(err, "failed to find spec replicas on MachineSet %s", klog.KObj(ms))
+		}
+		if found && replicas > 0 {
+			// Found old MachineSets that still has replicas => MD is still rolling out.
+			return true, nil
+		}
+		replicas, found, err = unstructured.NestedInt64(ms.UnstructuredContent(), "status", "replicas")
+		if err != nil {
+			return false, errors.Wrapf(err, "failed to find status replicas on MachineSet %s", klog.KObj(ms))
+		}
+		if found && replicas > 0 {
+			// Found old MachineSets that still has replicas => MD is still rolling out.
+			return true, nil
+		}
+	}
+
+	// Didn't find any old MachineSets that still have replicas => MD is not rolling out.
+	return false, nil
+}
+
 func newNodeGroupFromScalableResource(controller *machineController, unstructuredScalableResource *unstructured.Unstructured) (*nodegroup, error) {
 	// Ensure that the resulting node group would be allowed based on the autodiscovery specs if defined
 	if !controller.allowedByAutoDiscoverySpecs(unstructuredScalableResource) {

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_processors.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_processors.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterapi
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	klog "k8s.io/klog/v2"
+)
+
+// ScaleDownNodeUpgradeProcessor is a processor to filter out
+// nodes that are undergoing an upgrade through a MachineDeployment.
+type ScaleDownNodeUpgradeProcessor struct {
+	controller *machineController
+}
+
+// NewScaleDownNodeUpgradeProcessor returns a new ScaleDownNodeUpgradeProcessor for use when
+// registering a new upgrade scale down processor.
+func NewScaleDownNodeUpgradeProcessor(c *machineController) *ScaleDownNodeUpgradeProcessor {
+	return &ScaleDownNodeUpgradeProcessor{controller: c}
+}
+
+// GetPodDestinationCandidates returns nodes as is no processing is required here
+func (p *ScaleDownNodeUpgradeProcessor) GetPodDestinationCandidates(ctx *context.AutoscalingContext,
+	nodes []*apiv1.Node) ([]*apiv1.Node, errors.AutoscalerError) {
+	return nodes, nil
+}
+
+// GetScaleDownCandidates returns filter nodes based on if scale down is enabled or disabled per nodegroup.
+func (p *ScaleDownNodeUpgradeProcessor) GetScaleDownCandidates(ctx *context.AutoscalingContext,
+	nodes []*apiv1.Node) ([]*apiv1.Node, errors.AutoscalerError) {
+	result := []*apiv1.Node{}
+
+	for _, node := range nodes {
+		// check scale down, continue if not good
+		ng, err := p.controller.nodeGroupForNode(node)
+		if err != nil {
+			klog.Warningf("Error while checking node group for node %s: %v", node.Name, err)
+			continue
+		}
+		if ng == nil {
+			// this is at level 6 because the core scale down processor will already log this info
+			klog.V(6).Infof("Node %s will be skipped as it does not belong to a node group", node.Name)
+			continue
+		}
+
+		rollingout, err := ng.IsMachineDeploymentAndRollingOut()
+		if err != nil {
+			klog.Warningf("Failed to determine rolling out status for MachineDeployment %s: %v", ng.scalableResource.ID(), err)
+			continue
+		}
+
+		// A node is a good candidate for scale down if it is not currently part of a MachineDeployment that is rolling out.
+		if rollingout {
+			klog.V(4).Infof("Node %s will be skipped as it is currently under rollout", node.Name)
+			continue
+		}
+		result = append(result, node)
+	}
+	return result, nil
+}
+
+// CleanUp is called at CA termination.
+func (p *ScaleDownNodeUpgradeProcessor) CleanUp() {
+}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
@@ -54,6 +54,8 @@ const (
 	draDriverKey    = "capacity.cluster-autoscaler.kubernetes.io/dra-driver"
 	taintsKey       = "capacity.cluster-autoscaler.kubernetes.io/taints" // not currently used on OpenShift
 
+	machineDeploymentRevisionAnnotation = "machinedeployment.clusters.x-k8s.io/revision"
+	machineDeploymentNameLabel          = "cluster.x-k8s.io/deployment-name"
 	// UnknownArch is used if the Architecture is Unknown
 	UnknownArch SystemArchitecture = ""
 	// Amd64 is used if the Architecture is x86_64

--- a/cluster-autoscaler/cloudprovider/coreweave/coreweave_provider.go
+++ b/cluster-autoscaler/cloudprovider/coreweave/coreweave_provider.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
 	"k8s.io/klog/v2"
@@ -182,7 +183,7 @@ func (c *CoreWeaveCloudProvider) Refresh() error {
 }
 
 // BuildCoreWeave builds the CoreWeave cloud provider with the given options and returns it.
-func BuildCoreWeave(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
-	klog.V(4).Infof("Building CoreWeave cloud provider with options: %+v", opts)
-	return NewCoreWeaveCloudProvider(rl, opts)
+func BuildCoreWeave(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+	klog.V(4).Infof("Building CoreWeave cloud provider with options: %+v", opts.AutoscalingOptions)
+	return NewCoreWeaveCloudProvider(rl, opts.AutoscalingOptions)
 }

--- a/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/digitalocean/digitalocean_cloud_provider.go
@@ -25,7 +25,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	"k8s.io/klog/v2"
@@ -171,7 +171,7 @@ func (d *digitaloceanCloudProvider) Refresh() error {
 
 // BuildDigitalOcean builds the DigitalOcean cloud provider.
 func BuildDigitalOcean(
-	opts config.AutoscalingOptions,
+	opts *coreoptions.AutoscalerOptions,
 	do cloudprovider.NodeGroupDiscoveryOptions,
 	rl *cloudprovider.ResourceLimiter,
 ) cloudprovider.CloudProvider {

--- a/cluster-autoscaler/cloudprovider/equinixmetal/cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/equinixmetal/cloud_provider.go
@@ -28,8 +28,8 @@ import (
 	klog "k8s.io/klog/v2"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 )
@@ -180,7 +180,7 @@ func (pcp *equinixMetalCloudProvider) Cleanup() error {
 //
 // The equinixMetalManager is created here, and the node groups are created
 // based on the specs provided via the command line parameters.
-func BuildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func BuildCloudProvider(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	var config io.ReadCloser
 
 	if opts.CloudConfig != "" {
@@ -192,7 +192,7 @@ func BuildCloudProvider(opts config.AutoscalingOptions, do cloudprovider.NodeGro
 		defer config.Close()
 	}
 
-	manager, err := createEquinixMetalManager(config, do, opts)
+	manager, err := createEquinixMetalManager(config, do, opts.AutoscalingOptions)
 	if err != nil {
 		klog.Fatalf("Failed to create equinix metal manager: %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/exoscale/exoscale_cloud_provider.go
@@ -23,8 +23,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	egoscale "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/exoscale/internal/github.com/exoscale/egoscale/v2"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 )
@@ -225,7 +225,7 @@ func (e *exoscaleCloudProvider) Refresh() error {
 }
 
 // BuildExoscale builds the Exoscale cloud provider.
-func BuildExoscale(_ config.AutoscalingOptions, discoveryOpts cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func BuildExoscale(_ *coreoptions.AutoscalerOptions, discoveryOpts cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	manager, err := newManager(discoveryOpts)
 	if err != nil {
 		fatalf("failed to initialize manager: %v", err)

--- a/cluster-autoscaler/cloudprovider/externalgrpc/examples/external-grpc-cloud-provider-service/main.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/examples/external-grpc-cloud-provider-service/main.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/externalgrpc/protos"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/gce/localssdsize"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	kube_flag "k8s.io/component-base/cli/flag"
 	klog "k8s.io/klog/v2"
 )
@@ -115,17 +116,19 @@ func main() {
 	}
 
 	//cloud provider config
-	autoscalingOptions := config.AutoscalingOptions{
-		CloudProviderName:      *cloudProviderFlag,
-		CloudConfig:            *cloudConfig,
-		NodeGroupAutoDiscovery: *nodeGroupAutoDiscoveryFlag,
-		NodeGroups:             *nodeGroupsFlag,
-		ClusterName:            *clusterName,
-		GCEOptions: config.GCEOptions{
-			ConcurrentRefreshes:      1,
-			LocalSSDDiskSizeProvider: localssdsize.NewSimpleLocalSSDProvider(),
+	autoscalingOptions := &coreoptions.AutoscalerOptions{
+		AutoscalingOptions: config.AutoscalingOptions{
+			CloudProviderName:      *cloudProviderFlag,
+			CloudConfig:            *cloudConfig,
+			NodeGroupAutoDiscovery: *nodeGroupAutoDiscoveryFlag,
+			NodeGroups:             *nodeGroupsFlag,
+			ClusterName:            *clusterName,
+			GCEOptions: config.GCEOptions{
+				ConcurrentRefreshes:      1,
+				LocalSSDDiskSizeProvider: localssdsize.NewSimpleLocalSSDProvider(),
+			},
+			UserAgent: "user-agent",
 		},
-		UserAgent: "user-agent",
 	}
 	cloudProvider := cloudBuilder.NewCloudProvider(autoscalingOptions, nil)
 	srv := wrapper.NewCloudProviderGrpcWrapper(cloudProvider)

--- a/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/externalgrpc/externalgrpc_cloud_provider.go
@@ -35,7 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/externalgrpc/protos"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	klog "k8s.io/klog/v2"
@@ -318,7 +318,7 @@ func (e *externalGrpcCloudProvider) Refresh() error {
 
 // BuildExternalGrpc builds the externalgrpc cloud provider.
 func BuildExternalGrpc(
-	opts config.AutoscalingOptions,
+	opts *coreoptions.AutoscalerOptions,
 	do cloudprovider.NodeGroupDiscoveryOptions,
 	rl *cloudprovider.ResourceLimiter,
 ) cloudprovider.CloudProvider {

--- a/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/gce/gce_cloud_provider.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
@@ -376,7 +377,7 @@ func (mig *gceMig) TemplateNodeInfo() (*framework.NodeInfo, error) {
 }
 
 // BuildGCE builds GCE cloud provider, manager etc.
-func BuildGCE(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func BuildGCE(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	var config io.ReadCloser
 	if opts.CloudConfig != "" {
 		var err error

--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_cloud_provider.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/hetzner/hcloud-go/hcloud"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	autoscalerErrors "k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	"k8s.io/klog/v2"
@@ -183,7 +183,7 @@ func (d *HetznerCloudProvider) Refresh() error {
 }
 
 // BuildHetzner builds the Hetzner cloud provider.
-func BuildHetzner(_ config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func BuildHetzner(_ *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	manager, err := newManager()
 	if err != nil {
 		klog.Fatalf("Failed to create Hetzner manager: %v", err)

--- a/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud_cloud_provider.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	klog "k8s.io/klog/v2"
@@ -212,12 +213,12 @@ func (hcp *huaweicloudCloudProvider) addAsg(asg *AutoScalingGroup) {
 }
 
 // BuildHuaweiCloud is called by the autoscaler/cluster-autoscaler/builder to build a huaweicloud cloud provider.
-func BuildHuaweiCloud(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func BuildHuaweiCloud(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	if len(opts.CloudConfig) == 0 {
 		klog.Fatalf("cloud config is missing.")
 	}
 
-	return newCloudProvider(opts, do, rl)
+	return newCloudProvider(opts.AutoscalingOptions, do, rl)
 }
 
 func buildAsgFromSpec(specStr string, asgs []AutoScalingGroup, manager CloudServiceManager) (*AutoScalingGroup, error) {

--- a/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/ionoscloud/ionoscloud_cloud_provider.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	caerrors "k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
@@ -310,7 +311,7 @@ func (ic *IonosCloudCloudProvider) Refresh() error {
 
 // BuildIonosCloud builds the IonosCloud cloud provider.
 func BuildIonosCloud(
-	opts config.AutoscalingOptions,
+	opts *coreoptions.AutoscalerOptions,
 	_ cloudprovider.NodeGroupDiscoveryOptions,
 	rl *cloudprovider.ResourceLimiter,
 ) cloudprovider.CloudProvider {

--- a/cluster-autoscaler/cloudprovider/kamatera/kamatera_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/kamatera/kamatera_cloud_provider.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	klog "k8s.io/klog/v2"
@@ -131,7 +132,7 @@ func (k *kamateraCloudProvider) Refresh() error {
 
 // BuildKamatera builds the Kamatera cloud provider.
 func BuildKamatera(
-	opts config.AutoscalingOptions,
+	opts *coreoptions.AutoscalerOptions,
 	do cloudprovider.NodeGroupDiscoveryOptions,
 	rl *cloudprovider.ResourceLimiter,
 ) cloudprovider.CloudProvider {
@@ -143,7 +144,7 @@ func BuildKamatera(
 		klog.Fatalf("Could not open cloud provider configuration file %q, error: %v", opts.CloudConfig, err)
 	}
 	defer configFile.Close()
-	kcp, err := newKamateraCloudProvider(configFile, rl, createKubeClient(opts))
+	kcp, err := newKamateraCloudProvider(configFile, rl, createKubeClient(opts.AutoscalingOptions))
 	if err != nil {
 		klog.Fatalf("Could not create kamatera cloud provider: %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
+++ b/cluster-autoscaler/cloudprovider/kubemark/kubemark_linux.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
@@ -342,7 +343,7 @@ func buildNodeGroup(value string, kubemarkController *kubemark.KubemarkControlle
 }
 
 // BuildKubemark builds Kubemark cloud provider.
-func BuildKubemark(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func BuildKubemark(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	externalConfig, err := rest.InClusterConfig()
 	if err != nil {
 		klog.Fatalf("Failed to get kubeclient config for external cluster: %v", err)

--- a/cluster-autoscaler/cloudprovider/kwok/kwok_provider.go
+++ b/cluster-autoscaler/cloudprovider/kwok/kwok_provider.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	kube_util "k8s.io/autoscaler/cluster-autoscaler/utils/kubernetes"
@@ -171,7 +171,7 @@ func (kwok *KwokCloudProvider) Cleanup() error {
 }
 
 // BuildKwok builds kwok cloud provider.
-func BuildKwok(opts config.AutoscalingOptions,
+func BuildKwok(opts *coreoptions.AutoscalerOptions,
 	do cloudprovider.NodeGroupDiscoveryOptions,
 	rl *cloudprovider.ResourceLimiter,
 	informerFactory informers.SharedInformerFactory) cloudprovider.CloudProvider {
@@ -204,7 +204,7 @@ func BuildKwok(opts config.AutoscalingOptions,
 
 	p, err := BuildKwokProvider(&kwokOptions{
 		kubeClient:      kubeClient,
-		autoscalingOpts: &opts,
+		autoscalingOpts: &opts.AutoscalingOptions,
 		discoveryOpts:   &do,
 		resourceLimiter: rl,
 		ngNodeListerFn:  kube_util.NewNodeLister,

--- a/cluster-autoscaler/cloudprovider/linode/linode_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/linode/linode_cloud_provider.go
@@ -24,7 +24,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	klog "k8s.io/klog/v2"
@@ -121,7 +121,7 @@ func (l *linodeCloudProvider) Cleanup() error {
 
 // BuildLinode builds the BuildLinode cloud provider.
 func BuildLinode(
-	opts config.AutoscalingOptions,
+	opts *coreoptions.AutoscalerOptions,
 	do cloudprovider.NodeGroupDiscoveryOptions,
 	rl *cloudprovider.ResourceLimiter,
 ) cloudprovider.CloudProvider {

--- a/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/magnum/magnum_cloud_provider.go
@@ -28,8 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/magnum/gophercloud/openstack/containerinfra/v1/nodegroups"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	klog "k8s.io/klog/v2"
@@ -317,7 +317,7 @@ func (mcp *magnumCloudProvider) refreshNodeGroups() error {
 //
 // The magnumManager is created here, and the initial node groups are created
 // based on the static or auto discovery specs provided via the command line parameters.
-func BuildMagnum(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func BuildMagnum(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	var config io.ReadCloser
 
 	// Should be loaded with --cloud-config /etc/kubernetes/kube_openstack_config from master node.
@@ -338,7 +338,7 @@ func BuildMagnum(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDisco
 		klog.Fatal("can not use both static node group discovery and node group auto discovery")
 	}
 
-	manager, err := createMagnumManager(config, do, opts)
+	manager, err := createMagnumManager(config, do, opts.AutoscalingOptions)
 	if err != nil {
 		klog.Fatalf("Failed to create magnum manager: %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/oci/instancepools/oci_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/oci/instancepools/oci_cloud_provider.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/nodepools"
 	npconsts "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/oci/nodepools/consts"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	caerrors "k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	"k8s.io/client-go/kubernetes"
@@ -148,7 +149,7 @@ func (ocp *OciCloudProvider) Refresh() error {
 }
 
 // BuildOCI constructs the OciCloudProvider object that implements the could provider interface (InstancePoolManager).
-func BuildOCI(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func BuildOCI(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	ocidType, err := ocicommon.GetAllPoolTypes(opts.NodeGroups)
 	if err != nil {
 		klog.Fatalf("Failed to get pool type: %v", err)
@@ -160,7 +161,7 @@ func BuildOCI(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 	if strings.HasPrefix(ocidType, npconsts.OciNodePoolResourceIdent) && nodepoolTagsFound == true {
 		klog.Fatalf("-nodes and -node-group-auto-discovery parameters can not be used together.")
 	} else if strings.HasPrefix(ocidType, npconsts.OciNodePoolResourceIdent) || nodepoolTagsFound == true {
-		manager, err := nodepools.CreateNodePoolManager(opts.CloudConfig, opts.NodeGroupAutoDiscovery, do, createKubeClient(opts))
+		manager, err := nodepools.CreateNodePoolManager(opts.CloudConfig, opts.NodeGroupAutoDiscovery, do, createKubeClient(opts.AutoscalingOptions))
 		if err != nil {
 			klog.Fatalf("Could not create OCI OKE cloud provider: %v", err)
 		}
@@ -168,7 +169,7 @@ func BuildOCI(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 	}
 	// theoretically the only other possible value is no value (if no node groups are passed in)
 	// or instancepool, but either way, we'll just default to the instance pool implementation
-	ipManager, err := CreateInstancePoolManager(opts.CloudConfig, do, createKubeClient(opts))
+	ipManager, err := CreateInstancePoolManager(opts.CloudConfig, do, createKubeClient(opts.AutoscalingOptions))
 	if err != nil {
 		klog.Fatalf("Could not create OCI cloud provider: %v", err)
 	}

--- a/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/ovhcloud/ovh_cloud_provider.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/ovhcloud/sdk"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 )
@@ -59,7 +60,7 @@ type OVHCloudProvider struct {
 }
 
 // BuildOVHcloud builds the OVHcloud provider.
-func BuildOVHcloud(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func BuildOVHcloud(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	// Open cloud provider folder
 	var configFile io.ReadCloser
 	if opts.CloudConfig != "" {
@@ -82,7 +83,7 @@ func BuildOVHcloud(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDis
 	provider := &OVHCloudProvider{
 		manager: manager,
 
-		autoscalingOptions: opts,
+		autoscalingOptions: opts.AutoscalingOptions,
 		discoveryOptions:   do,
 		resourceLimiter:    rl,
 	}

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_provider.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_provider.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	autoscalererrors "k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	"k8s.io/client-go/discovery"
@@ -64,7 +64,7 @@ type RancherCloudProvider struct {
 }
 
 // BuildRancher builds rancher cloud provider.
-func BuildRancher(opts config.AutoscalingOptions, _ cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func BuildRancher(opts *coreoptions.AutoscalerOptions, _ cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	provider, err := newRancherCloudProvider(opts.CloudConfig, rl)
 	if err != nil {
 		klog.Fatalf("failed to create rancher cloud provider: %v", err)

--- a/cluster-autoscaler/cloudprovider/scaleway/scaleway_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/scaleway/scaleway_cloud_provider.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider/scaleway/scalewaygo"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	ca_errors "k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	"k8s.io/klog/v2"
@@ -103,7 +103,7 @@ func newScalewayCloudProvider(configFile io.Reader, defaultUserAgent string, rl 
 
 // BuildScaleway returns CloudProvider implementation for Scaleway.
 func BuildScaleway(
-	opts config.AutoscalingOptions,
+	opts *coreoptions.AutoscalerOptions,
 	do cloudprovider.NodeGroupDiscoveryOptions,
 	rl *cloudprovider.ResourceLimiter,
 ) cloudprovider.CloudProvider {

--- a/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/tencentcloud/tencentcloud_cloud_provider.go
@@ -24,7 +24,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	"k8s.io/klog/v2"
@@ -174,7 +174,7 @@ func (tencentcloud *tencentCloudProvider) Refresh() error {
 }
 
 // BuildTencentcloud returns tencentcloud provider
-func BuildTencentcloud(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func BuildTencentcloud(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	var config io.ReadCloser
 	if opts.CloudConfig != "" {
 		var err error

--- a/cluster-autoscaler/cloudprovider/utho/utho_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/utho/utho_cloud_provider.go
@@ -23,7 +23,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	"k8s.io/klog/v2"
@@ -164,7 +164,7 @@ func (u *uthoCloudProvider) Refresh() error {
 
 // BuildUtho builds the Utho cloud provider.
 func BuildUtho(
-	opts config.AutoscalingOptions,
+	opts *coreoptions.AutoscalerOptions,
 	do cloudprovider.NodeGroupDiscoveryOptions,
 	rl *cloudprovider.ResourceLimiter,
 ) cloudprovider.CloudProvider {

--- a/cluster-autoscaler/cloudprovider/volcengine/volcengine_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/volcengine/volcengine_cloud_provider.go
@@ -26,8 +26,8 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	"k8s.io/klog/v2"
@@ -160,7 +160,7 @@ func buildScalingGroupFromSpec(manager VolcengineManager, spec string) (*AutoSca
 }
 
 // BuildVolcengine builds CloudProvider implementation for Volcengine
-func BuildVolcengine(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func BuildVolcengine(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	if opts.CloudConfig == "" {
 		klog.Fatalf("The path to the cloud provider configuration file must be set via the --cloud-config command line parameter")
 	}

--- a/cluster-autoscaler/cloudprovider/vultr/vultr_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/vultr/vultr_cloud_provider.go
@@ -24,7 +24,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	"k8s.io/klog/v2"
@@ -151,7 +151,7 @@ func toNodeID(providerID string) string {
 }
 
 // BuildVultr builds the Vultr cloud provider.
-func BuildVultr(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
+func BuildVultr(opts *coreoptions.AutoscalerOptions, do cloudprovider.NodeGroupDiscoveryOptions, rl *cloudprovider.ResourceLimiter) cloudprovider.CloudProvider {
 	if opts.CloudConfig == "" {
 		klog.Fatalf("No config file provided, please specify it via the --cloud-config flag")
 	}

--- a/cluster-autoscaler/core/autoscaler.go
+++ b/cluster-autoscaler/core/autoscaler.go
@@ -20,52 +20,23 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	cloudBuilder "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/builder"
-	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/pdb"
-	"k8s.io/autoscaler/cluster-autoscaler/core/scaleup"
-	"k8s.io/autoscaler/cluster-autoscaler/debuggingsnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/estimator"
-	"k8s.io/autoscaler/cluster-autoscaler/expander"
 	"k8s.io/autoscaler/cluster-autoscaler/expander/factory"
 	"k8s.io/autoscaler/cluster-autoscaler/observers/loopstart"
 	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/predicate"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot/store"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules"
 	draprovider "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/provider"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
-	"k8s.io/autoscaler/cluster-autoscaler/simulator/options"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/backoff"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/client-go/informers"
-	kube_client "k8s.io/client-go/kubernetes"
 )
-
-// AutoscalerOptions is the whole set of options for configuring an autoscaler
-type AutoscalerOptions struct {
-	config.AutoscalingOptions
-	KubeClient             kube_client.Interface
-	InformerFactory        informers.SharedInformerFactory
-	AutoscalingKubeClients *context.AutoscalingKubeClients
-	CloudProvider          cloudprovider.CloudProvider
-	FrameworkHandle        *framework.Handle
-	ClusterSnapshot        clustersnapshot.ClusterSnapshot
-	ExpanderStrategy       expander.Strategy
-	EstimatorBuilder       estimator.EstimatorBuilder
-	Processors             *ca_processors.AutoscalingProcessors
-	LoopStartNotifier      *loopstart.ObserversList
-	Backoff                backoff.Backoff
-	DebuggingSnapshotter   debuggingsnapshot.DebuggingSnapshotter
-	RemainingPdbTracker    pdb.RemainingPdbTracker
-	ScaleUpOrchestrator    scaleup.Orchestrator
-	DeleteOptions          options.NodeDeleteOptions
-	DrainabilityRules      rules.Rules
-	DraProvider            *draprovider.Provider
-}
 
 // Autoscaler is the main component of CA which scales up/down node groups according to its configuration
 // The configuration can be injected at the creation of an autoscaler
@@ -83,7 +54,7 @@ type Autoscaler interface {
 }
 
 // NewAutoscaler creates an autoscaler of an appropriate type according to the parameters
-func NewAutoscaler(opts AutoscalerOptions, informerFactory informers.SharedInformerFactory) (Autoscaler, errors.AutoscalerError) {
+func NewAutoscaler(opts coreoptions.AutoscalerOptions, informerFactory informers.SharedInformerFactory) (Autoscaler, errors.AutoscalerError) {
 	err := initializeDefaultOptions(&opts, informerFactory)
 	if err != nil {
 		return nil, errors.ToAutoscalerError(errors.InternalError, err)
@@ -109,7 +80,7 @@ func NewAutoscaler(opts AutoscalerOptions, informerFactory informers.SharedInfor
 }
 
 // Initialize default options if not provided.
-func initializeDefaultOptions(opts *AutoscalerOptions, informerFactory informers.SharedInformerFactory) error {
+func initializeDefaultOptions(opts *coreoptions.AutoscalerOptions, informerFactory informers.SharedInformerFactory) error {
 	if opts.Processors == nil {
 		opts.Processors = ca_processors.DefaultProcessors(opts.AutoscalingOptions)
 	}
@@ -131,18 +102,6 @@ func initializeDefaultOptions(opts *AutoscalerOptions, informerFactory informers
 	}
 	if opts.RemainingPdbTracker == nil {
 		opts.RemainingPdbTracker = pdb.NewBasicRemainingPdbTracker()
-	}
-	if opts.CloudProvider == nil {
-		opts.CloudProvider = cloudBuilder.NewCloudProvider(opts.AutoscalingOptions, informerFactory)
-	}
-	if opts.ExpanderStrategy == nil {
-		expanderFactory := factory.NewFactory()
-		expanderFactory.RegisterDefaultExpanders(opts.CloudProvider, opts.AutoscalingKubeClients, opts.KubeClient, opts.ConfigNamespace, opts.GRPCExpanderCert, opts.GRPCExpanderURL)
-		expanderStrategy, err := expanderFactory.Build(strings.Split(opts.ExpanderNames, ","))
-		if err != nil {
-			return err
-		}
-		opts.ExpanderStrategy = expanderStrategy
 	}
 	if opts.EstimatorBuilder == nil {
 		thresholds := []estimator.Threshold{
@@ -170,6 +129,18 @@ func initializeDefaultOptions(opts *AutoscalerOptions, informerFactory informers
 	}
 	if opts.DraProvider == nil && opts.DynamicResourceAllocationEnabled {
 		opts.DraProvider = draprovider.NewProviderFromInformers(informerFactory)
+	}
+	if opts.CloudProvider == nil {
+		opts.CloudProvider = cloudBuilder.NewCloudProvider(opts, informerFactory)
+	}
+	if opts.ExpanderStrategy == nil {
+		expanderFactory := factory.NewFactory()
+		expanderFactory.RegisterDefaultExpanders(opts.CloudProvider, opts.AutoscalingKubeClients, opts.KubeClient, opts.ConfigNamespace, opts.GRPCExpanderCert, opts.GRPCExpanderURL)
+		expanderStrategy, err := expanderFactory.Build(strings.Split(opts.ExpanderNames, ","))
+		if err != nil {
+			return err
+		}
+		opts.ExpanderStrategy = expanderStrategy
 	}
 
 	return nil

--- a/cluster-autoscaler/core/options/autoscaler.go
+++ b/cluster-autoscaler/core/options/autoscaler.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
+	"k8s.io/autoscaler/cluster-autoscaler/context"
+	"k8s.io/autoscaler/cluster-autoscaler/core/scaledown/pdb"
+	"k8s.io/autoscaler/cluster-autoscaler/core/scaleup"
+	"k8s.io/autoscaler/cluster-autoscaler/debuggingsnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/estimator"
+	"k8s.io/autoscaler/cluster-autoscaler/expander"
+	"k8s.io/autoscaler/cluster-autoscaler/observers/loopstart"
+	ca_processors "k8s.io/autoscaler/cluster-autoscaler/processors"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/clustersnapshot"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/drainability/rules"
+	draprovider "k8s.io/autoscaler/cluster-autoscaler/simulator/dynamicresources/provider"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
+	"k8s.io/autoscaler/cluster-autoscaler/simulator/options"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/backoff"
+	"k8s.io/client-go/informers"
+	kube_client "k8s.io/client-go/kubernetes"
+)
+
+// AutoscalerOptions is the whole set of options for configuring an autoscaler
+type AutoscalerOptions struct {
+	config.AutoscalingOptions
+	KubeClient             kube_client.Interface
+	InformerFactory        informers.SharedInformerFactory
+	AutoscalingKubeClients *context.AutoscalingKubeClients
+	CloudProvider          cloudprovider.CloudProvider
+	FrameworkHandle        *framework.Handle
+	ClusterSnapshot        clustersnapshot.ClusterSnapshot
+	ExpanderStrategy       expander.Strategy
+	EstimatorBuilder       estimator.EstimatorBuilder
+	Processors             *ca_processors.AutoscalingProcessors
+	LoopStartNotifier      *loopstart.ObserversList
+	Backoff                backoff.Backoff
+	DebuggingSnapshotter   debuggingsnapshot.DebuggingSnapshotter
+	RemainingPdbTracker    pdb.RemainingPdbTracker
+	ScaleUpOrchestrator    scaleup.Orchestrator
+	DeleteOptions          options.NodeDeleteOptions
+	DrainabilityRules      rules.Rules
+	DraProvider            *draprovider.Provider
+}

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -51,6 +51,7 @@ import (
 	capacitybuffer "k8s.io/autoscaler/cluster-autoscaler/capacitybuffer/controller"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/core"
+	coreoptions "k8s.io/autoscaler/cluster-autoscaler/core/options"
 	"k8s.io/autoscaler/cluster-autoscaler/core/podlistprocessor"
 	"k8s.io/autoscaler/cluster-autoscaler/metrics"
 	"k8s.io/autoscaler/cluster-autoscaler/observers/loopstart"
@@ -122,7 +123,7 @@ func buildAutoscaler(context ctx.Context, debuggingSnapshotter debuggingsnapshot
 	drainabilityRules := rules.Default(deleteOptions)
 
 	var snapshotStore clustersnapshot.ClusterSnapshotStore = store.NewDeltaSnapshotStore(autoscalingOptions.ClusterSnapshotParallelism)
-	opts := core.AutoscalerOptions{
+	opts := coreoptions.AutoscalerOptions{
 		AutoscalingOptions:   autoscalingOptions,
 		FrameworkHandle:      fwHandle,
 		ClusterSnapshot:      predicate.NewPredicateSnapshot(snapshotStore, fwHandle, autoscalingOptions.DynamicResourceAllocationEnabled),
@@ -234,6 +235,10 @@ func buildAutoscaler(context ctx.Context, debuggingSnapshotter debuggingsnapshot
 	if len(autoscalingOptions.BalancingLabels) > 0 {
 		nodeInfoComparator = nodegroupset.CreateLabelNodeInfoComparator(autoscalingOptions.BalancingLabels)
 	} else {
+		// TODO elmiko - now that we are passing the AutoscalerOptions in to the
+		// NewCloudProvider function, we should migrate these cloud provider specific
+		// configurations to the NewCloudProvider method so that we remove more provider
+		// code from the core.
 		nodeInfoComparatorBuilder := nodegroupset.CreateGenericNodeInfoComparator
 		if autoscalingOptions.CloudProviderName == cloudprovider.AzureProviderName {
 			nodeInfoComparatorBuilder = nodegroupset.CreateAzureNodeInfoComparator

--- a/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_processor.go
+++ b/cluster-autoscaler/processors/scaledowncandidates/scale_down_candidates_processor.go
@@ -17,6 +17,8 @@ limitations under the License.
 package scaledowncandidates
 
 import (
+	"fmt"
+
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/cluster-autoscaler/context"
 	"k8s.io/autoscaler/cluster-autoscaler/processors/nodes"
@@ -69,4 +71,17 @@ func (p *combinedScaleDownCandidatesProcessor) CleanUp() {
 	for _, processor := range p.processors {
 		processor.CleanUp()
 	}
+}
+
+// RegisterCombinedScaleDownCandidateProcessor registers a new ScaleDownNodeProcessor with
+// a CombinedScaleDownCandidatesProcessor. This function will return an error if the
+// processor receiving the registration is not a CombinedScaleDownCandidatesProcessor.
+func RegisterCombinedScaleDownCandidateProcessor(combinedProcessor, processorToAdd nodes.ScaleDownNodeProcessor) error {
+	combinedProcessorConcrete, ok := combinedProcessor.(*combinedScaleDownCandidatesProcessor)
+	if !ok {
+		return fmt.Errorf("wrong concrete ScaleDownNodeProcessor type: want *scaledowncandidates.CombinedScaleDownCandidatesProcessor, got %T", combinedProcessor)
+	}
+	combinedProcessorConcrete.Register(processorToAdd)
+
+	return nil
 }


### PR DESCRIPTION
this change refactors how cloud providers are created so that providers can inject a custom scale down processor. it also adds an upgrade processor for cluster-api to allow skipping machinedeployments that are undergoing upgrade.