### PR TITLE
OCPBUGS-78152: allow clusterapi provider to skip paused resources

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -766,6 +766,13 @@ func (c *machineController) nodeGroups() ([]cloudprovider.NodeGroup, error) {
 		}
 
 		if ng != nil {
+			if isScalableResourceAndPaused(*r) {
+				// if the resource is paused from reconciling by cluster api controllers, we don't want to include it
+				// as an active node group.
+				klog.V(4).Infof("discovered a paused node group: %s", ng.Debug())
+				continue
+			}
+
 			nodegroups = append(nodegroups, ng)
 			klog.V(4).Infof("discovered node group: %s", ng.Debug())
 		}
@@ -779,6 +786,13 @@ func (c *machineController) nodeGroupForNode(node *corev1.Node) (*nodegroup, err
 		return nil, err
 	}
 	if scalableResource == nil {
+		return nil, nil
+	}
+
+	// if the scalable resource associated with this node is paused, we do not want to associate
+	// the node with a node group as the group will also be paused. we return nil here to ensure
+	// that the core autoscaler does not try to remove the node while it is paused.
+	if isScalableResourceAndPaused(*scalableResource) {
 		return nil, nil
 	}
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_provider_test.go
@@ -18,6 +18,7 @@ package clusterapi
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -101,6 +102,7 @@ func TestProviderConstructorProperties(t *testing.T) {
 		t.Fatalf("expected 0 GPU types, got %d", got)
 	}
 }
+
 func BenchmarkNodeGroups(b *testing.B) {
 	resourceLimits := cloudprovider.ResourceLimiter{}
 	annotations := map[string]string{
@@ -132,4 +134,142 @@ func BenchmarkNodeGroups(b *testing.B) {
 			provider.NodeGroups()
 		}
 	})
+}
+
+func TestNodeGroups(t *testing.T) {
+	resourceLimits := cloudprovider.ResourceLimiter{}
+	annotations := map[string]string{
+		nodeGroupMinSizeAnnotationKey: "1",
+		nodeGroupMaxSizeAnnotationKey: "2",
+	}
+	pausedAnnotations := map[string]string{
+		resourcePausedAnnotation: "true",
+	}
+
+	testConfigs := []struct {
+		name                    string
+		scalableResourceConfigs []*TestConfig
+		expectedNodeGroupCount  int
+	}{
+		{
+			"no node groups return empty list",
+			[]*TestConfig{},
+			0,
+		},
+		{
+			"multiple MachineSet node groups without scaling enabled returns empty list",
+			NewTestConfigBuilder().
+				ForMachineSet().
+				WithNamespace("namespace").
+				WithClusterName("").
+				WithNodeCount(1).
+				BuildMultiple(10),
+			0,
+		},
+		{
+			"multiple MachineDeployment node groups without scaling enabled returns empty list",
+			NewTestConfigBuilder().
+				ForMachineDeployment().
+				WithNamespace("namespace").
+				WithClusterName("").
+				WithNodeCount(1).
+				BuildMultiple(10),
+			0,
+		},
+		{
+			"multiple MachineSet node groups with scaling enabled returns correct length",
+			NewTestConfigBuilder().
+				ForMachineSet().
+				WithNamespace("namespace").
+				WithClusterName("").
+				WithNodeCount(1).
+				WithAnnotations(annotations).
+				BuildMultiple(10),
+			10,
+		},
+		{
+			"multiple MachineDeployment node groups with scaling enabled returns correct length",
+			NewTestConfigBuilder().
+				ForMachineDeployment().
+				WithNamespace("namespace").
+				WithClusterName("").
+				WithNodeCount(1).
+				WithAnnotations(annotations).
+				BuildMultiple(10),
+			10,
+		},
+		{
+			"multiple paused MachineSet node groups with scaling enabled returns correct length",
+			NewTestConfigBuilder().
+				ForMachineSet().
+				WithNamespace("namespace").
+				WithClusterName("").
+				WithNodeCount(1).
+				WithAnnotations(annotations).
+				WithAnnotations(pausedAnnotations).
+				BuildMultiple(10),
+			0,
+		},
+		{
+			"multiple paused MachineDeployment node groups with scaling enabled returns correct length",
+			NewTestConfigBuilder().
+				ForMachineDeployment().
+				WithNamespace("namespace").
+				WithClusterName("").
+				WithNodeCount(1).
+				WithAnnotations(annotations).
+				WithAnnotations(pausedAnnotations).
+				BuildMultiple(10),
+			0,
+		},
+		{
+			"blend of paused, unpaused, and non-scaling node groups returns correct length",
+			slices.Concat(
+				NewTestConfigBuilder().
+					ForMachineDeployment().
+					WithNamespace("namespace").
+					WithClusterName("").
+					WithNodeCount(1).
+					WithAnnotations(annotations).
+					WithAnnotations(pausedAnnotations).
+					BuildMultiple(5),
+				NewTestConfigBuilder().
+					ForMachineDeployment().
+					WithNamespace("namespace").
+					WithClusterName("").
+					WithNodeCount(1).
+					WithAnnotations(annotations).
+					BuildMultiple(5),
+				NewTestConfigBuilder().
+					ForMachineDeployment().
+					WithNamespace("namespace").
+					WithClusterName("").
+					WithNodeCount(1).
+					BuildMultiple(5),
+			),
+			5,
+		},
+	}
+
+	for _, tc := range testConfigs {
+		controller := NewTestMachineController(t)
+
+		if len(tc.scalableResourceConfigs) > 0 {
+			if err := controller.AddTestConfigs(tc.scalableResourceConfigs...); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		}
+
+		provider := newProvider(cloudprovider.ClusterAPIProviderName, &resourceLimits, controller.machineController)
+		if actual := provider.Name(); actual != cloudprovider.ClusterAPIProviderName {
+			t.Errorf("expected %q, got %q", cloudprovider.ClusterAPIProviderName, actual)
+		}
+
+		observed := provider.NodeGroups()
+		if len(observed) != tc.expectedNodeGroupCount {
+			t.Fatalf("unexpected node group length, expected: %d, observed %d", tc.expectedNodeGroupCount, observed)
+		}
+
+		controller.Stop()
+	}
 }

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -691,3 +691,16 @@ func parseTaint(st string) (apiv1.Taint, error) {
 
 	return taint, nil
 }
+
+// returns true if the unstructured resource is a MachineDeployment, MachinePool, or MachineSet,
+// and contains the pause annotation.
+func isScalableResourceAndPaused(resource unstructured.Unstructured) bool {
+	switch resource.GetKind() {
+	case machineDeploymentKind, machinePoolKind, machineSetKind:
+		annotations := resource.GetAnnotations()
+		if _, found := annotations[resourcePausedAnnotation]; found {
+			return true
+		}
+	}
+	return false
+}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
@@ -56,6 +56,7 @@ const (
 	csiDriverKey                        = "capacity.cluster-autoscaler.kubernetes.io/csi-driver"
 	machineDeploymentRevisionAnnotation = "machinedeployment.clusters.x-k8s.io/revision"
 	machineDeploymentNameLabel          = "cluster.x-k8s.io/deployment-name"
+	resourcePausedAnnotation            = "cluster.x-k8s.io/paused"
 
 	// UnknownArch is used if the Architecture is Unknown
 	UnknownArch SystemArchitecture = ""


### PR DESCRIPTION
This change adds a function to detect when scalable resource types (MachineDeployment, MachineSet, or MachinePool) have the the cluster api pause annotation. When found, these scalable resources will not be reported to the core autoscaler.
