### PR TITLE
[release-4.16] OCPBUGS-78702: allow clusterapi provider to skip paused resources

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -756,6 +756,13 @@ func (c *machineController) nodeGroups() ([]cloudprovider.NodeGroup, error) {
 		}
 
 		if ng != nil {
+			if isScalableResourceAndPaused(*r) {
+				// if the resource is paused from reconciling by cluster api controllers, we don't want to include it
+				// as an active node group.
+				klog.V(4).Infof("discovered a paused node group: %s", ng.Debug())
+				continue
+			}
+
 			nodegroups = append(nodegroups, ng)
 			klog.V(4).Infof("discovered node group: %s", ng.Debug())
 		}
@@ -769,6 +776,13 @@ func (c *machineController) nodeGroupForNode(node *corev1.Node) (*nodegroup, err
 		return nil, err
 	}
 	if scalableResource == nil {
+		return nil, nil
+	}
+
+	// if the scalable resource associated with this node is paused, we do not want to associate
+	// the node with a node group as the group will also be paused. we return nil here to ensure
+	// that the core autoscaler does not try to remove the node while it is paused.
+	if isScalableResourceAndPaused(*scalableResource) {
 		return nil, nil
 	}
 

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_unstructured.go
@@ -531,3 +531,16 @@ func parseTaint(st string) (apiv1.Taint, error) {
 
 	return taint, nil
 }
+
+// returns true if the unstructured resource is a MachineDeployment, MachinePool, or MachineSet,
+// and contains the pause annotation.
+func isScalableResourceAndPaused(resource unstructured.Unstructured) bool {
+	switch resource.GetKind() {
+	case machineDeploymentKind, machinePoolKind, machineSetKind:
+		annotations := resource.GetAnnotations()
+		if _, found := annotations[resourcePausedAnnotation]; found {
+			return true
+		}
+	}
+	return false
+}

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go
@@ -43,10 +43,11 @@ const (
 	gpuCountKey = "machine.openshift.io/GPU"
 	maxPodsKey  = "machine.openshift.io/maxPods"
 	// the following constants keep the upstream prefix so that we do not introduce separate values into the openshift api
-	diskCapacityKey = "capacity.cluster-autoscaler.kubernetes.io/ephemeral-disk"
-	labelsKey       = "capacity.cluster-autoscaler.kubernetes.io/labels"
-	gpuTypeKey      = "capacity.cluster-autoscaler.kubernetes.io/gpu-type" // not currently used on OpenShift
-	taintsKey       = "capacity.cluster-autoscaler.kubernetes.io/taints"   // not currently used on OpenShift
+	diskCapacityKey          = "capacity.cluster-autoscaler.kubernetes.io/ephemeral-disk"
+	labelsKey                = "capacity.cluster-autoscaler.kubernetes.io/labels"
+	gpuTypeKey               = "capacity.cluster-autoscaler.kubernetes.io/gpu-type" // not currently used on OpenShift
+	taintsKey                = "capacity.cluster-autoscaler.kubernetes.io/taints"   // not currently used on OpenShift
+	resourcePausedAnnotation = "cluster.x-k8s.io/paused"
 
 	// UnknownArch is used if the Architecture is Unknown
 	UnknownArch SystemArchitecture = ""


### PR DESCRIPTION
This change adds a function to detect when scalable resource types (MachineDeployment, MachineSet, or MachinePool) have the the cluster api pause annotation. When found, these scalable resources will not be reported to the core autoscaler.
