### PR TITLE
OCPBUGS-92799: UPSTREAM: 10001: chore(clusterapi): add machine phase check for failed machines

### DIFF
--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_controller.go
@@ -66,6 +66,8 @@ const (
 	autoDiscovererTypeClusterAPI  = "clusterapi"
 	autoDiscovererClusterNameKey  = "clusterName"
 	autoDiscovererNamespaceKey    = "namespace"
+
+	machinePhaseFailed = "Failed"
 )
 
 // machineController watches for Nodes, Machines, MachinePools, MachineSets, and
@@ -685,14 +687,24 @@ func (c *machineController) findScalableResourceProviderIDs(scalableResource *un
 		}
 
 		if found {
-			// Provide a normalized ID to allow the autoscaler to track machines that will never
-			// become nodes and mark the nodegroup unhealthy after maxNodeProvisionTime.
-			// Fake ID needs to be recognised later and converted into a machine key.
-			// Use an underscore as a separator between namespace and name as it is not a
-			// valid character within a namespace name.
-			klog.V(4).Infof("Status.FailureMessage of machine %q is %q", machine.GetName(), failureMessage)
-			providerIDs = append(providerIDs, createFailedMachineNormalizedProviderID(machine.GetNamespace(), machine.GetName()))
-			continue
+			machinePhase, found, err := unstructured.NestedString(machine.UnstructuredContent(), "status", "phase")
+			if err != nil {
+				return nil, err
+			}
+
+			if found && machinePhase == machinePhaseFailed {
+				// Provide a normalized ID to allow the autoscaler to track machines that will never
+				// become nodes and mark the nodegroup unhealthy after maxNodeProvisionTime.
+				// Fake ID needs to be recognised later and converted into a machine key.
+				// Use an underscore as a separator between namespace and name as it is not a
+				// valid character within a namespace name.
+
+				// TODO(LucasAndFlores): once we moved to the version 1.15, we should exclude the check for failed machine (lines 684-708), since this state was deprecated.
+				// Ref: https://cluster-api.sigs.k8s.io/developer/providers/migrations/v1.10-to-v1.11#deprecations
+				klog.V(4).Infof("Status.FailureMessage of machine %q is %q", machine.GetName(), failureMessage)
+				providerIDs = append(providerIDs, createFailedMachineNormalizedProviderID(machine.GetNamespace(), machine.GetName()))
+				continue
+			}
 		}
 
 		// Deleting Machines

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -2100,6 +2100,7 @@ func TestNodeGroupNodesInstancesStatus(t *testing.T) {
 			machine := testConfig.machines[3].DeepCopy()
 			unstructured.RemoveNestedField(machine.Object, "status", "nodeRef")
 			unstructured.SetNestedField(machine.Object, "ErrorMessage", "status", "errorMessage")
+			unstructured.SetNestedField(machine.Object, "Failed", "status", "phase")
 
 			if err := controller.UpdateResource(controller.machineInformer, controller.machineResource, machine); err != nil {
 				t.Fatalf("unexpected error updating machine, got %v", err)

--- a/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup_test.go
@@ -491,6 +491,7 @@ func TestNodeGroupDecreaseTargetSize(t *testing.T) {
 				unstructured.RemoveNestedField(machine.Object, "spec", "providerID")
 			}
 			unstructured.SetNestedField(machine.Object, "FailureMessage", "status", "failureMessage")
+			unstructured.SetNestedField(machine.Object, "Failed", "status", "phase")
 
 			if err := controller.UpdateResource(controller.machineInformer, controller.machineResource, machine); err != nil {
 				t.Fatalf("unexpected error updating machine, got %v", err)
@@ -1405,6 +1406,10 @@ func TestNodeGroupWithFailedMachine(t *testing.T) {
 			t.Fatalf("unexpected error setting nested field: %v", err)
 		}
 
+		if err := unstructured.SetNestedField(machine.Object, "Failed", "status", "phase"); err != nil {
+			t.Fatalf("unexpected error setting nested field: %v", err)
+		}
+
 		if err := controller.UpdateResource(controller.machineInformer, controller.machineResource, machine); err != nil {
 			t.Fatalf("unexpected error updating machine, got %v", err)
 		}
@@ -2080,6 +2085,7 @@ func TestNodeGroupNodesInstancesStatus(t *testing.T) {
 			machine := testConfig.machines[2].DeepCopy()
 			unstructured.SetNestedField(machine.Object, "node-1", "status", "nodeRef", "name")
 			unstructured.SetNestedField(machine.Object, "ErrorMessage", "status", "errorMessage")
+			unstructured.SetNestedField(machine.Object, "Failed", "status", "phase")
 
 			if err := controller.UpdateResource(controller.machineInformer, controller.machineResource, machine); err != nil {
 				t.Fatalf("unexpected error updating machine, got %v", err)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### Which issue(s) this PR fixes: NONE

#### What this PR does / why we need it:
Recently, one of our clients related that one of the clusterapi providers are marking machines as failed, but the machines were in `Provisioning` state. You can find the issue [here](https://github.com/openshift/cluster-api-provider-baremetal/issues/257).
In order to fix this behavior, I talked with @elmiko and we thought that check the machine phase during the scale up is the better place to fix this. This fix (and the condition of failed machine) should be removed in the near future, since this state has been deprecated.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```